### PR TITLE
fix: omit internal id prop from editor and parent removal on last child removal

### DIFF
--- a/src/components/CredentialRequestsEditor/components/CredentialRequestsField.tsx
+++ b/src/components/CredentialRequestsEditor/components/CredentialRequestsField.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { Stack } from '@mui/material';
 import { Add } from '@mui/icons-material';
-import { useFieldArray, useFormContext } from 'react-hook-form';
+import {
+  useFieldArray,
+  type UseFieldArrayReturn,
+  useFormContext,
+} from 'react-hook-form';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 
@@ -19,8 +23,15 @@ import {
 
 function CredentialRequestField({
   path = 'credentialRequests',
+  parentFieldArray,
+  parentIndex = 0,
   level = 0,
-}: Readonly<{ path?: string; level?: number }>): React.JSX.Element {
+}: Readonly<{
+  path?: string;
+  parentFieldArray?: UseFieldArrayReturn<CredentialRequestsEditorForm>;
+  parentIndex?: number;
+  level?: number;
+}>): React.JSX.Element {
   const customConfig = useCredentialRequestsEditor();
   const form = useFormContext<CredentialRequestsEditorForm>();
   const fieldArray = useFieldArray<CredentialRequestsEditorForm>({
@@ -40,12 +51,17 @@ function CredentialRequestField({
             fieldArray={fieldArray}
             index={index}
             level={level}
+            onAllFieldsDelete={() => {
+              (parentFieldArray ?? fieldArray)?.remove(parentIndex);
+            }}
           >
             <DataFieldAccordion />
             {Array.isArray(field.children) && (
               <CredentialRequestField
                 key={`${_path}.children`}
                 path={`${_path}.children`}
+                parentFieldArray={fieldArray}
+                parentIndex={index}
                 level={level + 1}
               />
             )}

--- a/src/components/CredentialRequestsEditor/components/DataFieldAccordion.tsx
+++ b/src/components/CredentialRequestsEditor/components/DataFieldAccordion.tsx
@@ -131,6 +131,14 @@ export function DataFieldAccordion(
   const handleRemove = (): void => {
     if (!credentialRequestField) return;
     setModalOpen(false);
+
+    // Delete parent when the last field was removed from the stack of form fields.
+    // The validation should be against less or equal than 1 because is against a previous state check.
+    if (credentialRequestField.fieldArray.fields.length <= 1) {
+      credentialRequestField.onAllFieldsDelete();
+      return;
+    }
+
     credentialRequestField.fieldArray.remove(credentialRequestField.index);
   };
 

--- a/src/components/CredentialRequestsEditor/contexts/CredentialRequestFieldContext.tsx
+++ b/src/components/CredentialRequestsEditor/contexts/CredentialRequestFieldContext.tsx
@@ -18,6 +18,7 @@ type CredentialRequestFieldContext = PropsWithChildren & {
   >;
   index: number;
   level: number;
+  onAllFieldsDelete: () => void;
 };
 
 const Context = createContext<CredentialRequestFieldContext | null>(null);


### PR DESCRIPTION
## Summary
Omit `id` internal editor prop from the event containing the credential requests state. Another fix on editor was the removal of parent credential request when the last child is removed, this avoids creation of a composite credential with empty children.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- fix change event

## Testing
Locally changing all values.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects