### PR TITLE
fix: add default value for multi

### DIFF
--- a/src/components/CredentialRequestsEditor/components/DataFieldMulti.tsx
+++ b/src/components/CredentialRequestsEditor/components/DataFieldMulti.tsx
@@ -24,7 +24,7 @@ export function DataFieldMulti(): React.JSX.Element {
       }
     >
       <RadioGroup
-        value={multi.field.value}
+        value={multi.field.value || false}
         onChange={(_, value) => {
           // Update form state
           multi.field.onChange({


### PR DESCRIPTION
## Summary
Add default value to multi when field is undefined.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- fix default radio group value

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects