### PR TITLE
fix: omit multi from nested data fields

### DIFF
--- a/src/components/CredentialRequestsEditor/components/DataFieldMulti.tsx
+++ b/src/components/CredentialRequestsEditor/components/DataFieldMulti.tsx
@@ -6,11 +6,13 @@ import { useCredentialRequestField } from '../contexts/CredentialRequestFieldCon
 import { RadioOption } from './RadioOption';
 import { DataFieldSection } from './DataFieldSection';
 
-export function DataFieldMulti(): React.JSX.Element {
+export function DataFieldMulti(): React.JSX.Element | null {
   const credentialRequestField = useCredentialRequestField();
   const multi = useController<CredentialRequestsEditorForm>({
     name: `${credentialRequestField?.path as any}.multi` as any,
   });
+
+  if ((credentialRequestField?.level || 0) > 0) return null;
 
   return (
     <DataFieldSection


### PR DESCRIPTION
## Summary
Displays only `multi` option to top-level data fields.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- updated data field multi renderer

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects