### PR TITLE
chore: default multi to true for email

### DIFF
--- a/src/components/CredentialRequestsEditor/utils/buildDataFieldValue.ts
+++ b/src/components/CredentialRequestsEditor/utils/buildDataFieldValue.ts
@@ -59,6 +59,7 @@ export function buildDataFieldValue(
     mandatory: MandatoryEnum.NO,
     description: '',
     allowUserInput: true,
-    multi: false,
+    // We want to default to true if is email credential.
+    multi: type === 'EmailCredential',
   };
 }


### PR DESCRIPTION
## Summary
Set default multi to `true` when email credential on Credential Requests Editor.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- update credential request factory

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects