### PR TITLE
feat: allow to control description, mandatory, allowUserInput fields

### DIFF
--- a/src/components/CredentialRequestsEditor/CredentialRequestsEditor.context.tsx
+++ b/src/components/CredentialRequestsEditor/CredentialRequestsEditor.context.tsx
@@ -11,6 +11,15 @@ import {
 } from './types/form';
 
 export interface CredentialRequestsEditorFeatures {
+  allowUserInput?: {
+    disabled?: boolean;
+  };
+  description?: {
+    disabled?: boolean;
+  };
+  mandatory?: {
+    disabled?: boolean;
+  };
   multi?: {
     disabled?: boolean;
   };

--- a/src/components/CredentialRequestsEditor/components/DataFieldDescription.tsx
+++ b/src/components/CredentialRequestsEditor/components/DataFieldDescription.tsx
@@ -4,10 +4,14 @@ import debounce from 'lodash/debounce';
 import { TextField } from '@mui/material';
 
 import { type CredentialRequestsEditorForm } from '../types/form';
+import { useCredentialRequestsEditor } from '../CredentialRequestsEditor.context';
 import { useCredentialRequestField } from '../contexts/CredentialRequestFieldContext';
 import { DataFieldSection } from './DataFieldSection';
 
 export function DataFieldDescription(): React.JSX.Element {
+  const { features } = useCredentialRequestsEditor();
+  const isFeatureDisabled = features?.description?.disabled === true;
+
   const credentialRequestField = useCredentialRequestField();
   const description = useController<CredentialRequestsEditorForm>({
     name: `${credentialRequestField?.path as any}.description` as any,
@@ -22,6 +26,7 @@ export function DataFieldDescription(): React.JSX.Element {
   ).current;
 
   const handleChange = (e: any): void => {
+    if (isFeatureDisabled) return;
     setValue(e.target.value);
     debounceChange(e.target.value);
   };
@@ -36,6 +41,9 @@ export function DataFieldDescription(): React.JSX.Element {
           <pre>{`{\n  description?: string\n}`}</pre>
         </>
       }
+      sx={{
+        opacity: isFeatureDisabled ? 0.5 : 1,
+      }}
     >
       <TextField
         {...description.field}
@@ -53,6 +61,7 @@ export function DataFieldDescription(): React.JSX.Element {
         inputProps={{
           'data-testid': 'custom-demo-dialog-data-field-description-input',
         }}
+        disabled={isFeatureDisabled}
       />
     </DataFieldSection>
   );

--- a/src/components/CredentialRequestsEditor/components/DataFieldMandatory.tsx
+++ b/src/components/CredentialRequestsEditor/components/DataFieldMandatory.tsx
@@ -3,11 +3,15 @@ import { RadioGroup } from '@mui/material';
 
 import { type CredentialRequestsEditorForm } from '../types/form';
 import { MandatoryEnum } from '../types/mandatoryEnum';
+import { useCredentialRequestsEditor } from '../CredentialRequestsEditor.context';
 import { useCredentialRequestField } from '../contexts/CredentialRequestFieldContext';
 import { RadioOption } from './RadioOption';
 import { DataFieldSection } from './DataFieldSection';
 
 export function DataFieldMandatory(): React.JSX.Element {
+  const { features } = useCredentialRequestsEditor();
+  const isFeatureDisabled = features?.mandatory?.disabled === true;
+
   const credentialRequestField = useCredentialRequestField();
   const mandatory = useController<CredentialRequestsEditorForm>({
     name: `${credentialRequestField?.path as any}.mandatory` as any,
@@ -23,10 +27,14 @@ export function DataFieldMandatory(): React.JSX.Element {
           <pre>{`{\n  mandatory?: enum\n}`}</pre>
         </>
       }
+      sx={{
+        opacity: isFeatureDisabled ? 0.5 : 1,
+      }}
     >
       <RadioGroup
         value={mandatory.field.value}
         onChange={(e) => {
+          if (isFeatureDisabled) return;
           const value = e.target.value as MandatoryEnum;
 
           // Update form state
@@ -44,6 +52,7 @@ export function DataFieldMandatory(): React.JSX.Element {
               'data-testid': 'custom-demo-dialog-mandatory-no-radio',
             } as any
           }
+          disabled={isFeatureDisabled}
         />
         <RadioOption
           value={MandatoryEnum.IF_AVAILABLE}
@@ -55,6 +64,7 @@ export function DataFieldMandatory(): React.JSX.Element {
               'data-testid': 'custom-demo-dialog-mandatory-if_available-radio',
             } as any
           }
+          disabled={isFeatureDisabled}
         />
         <RadioOption
           value={MandatoryEnum.YES}
@@ -66,6 +76,7 @@ export function DataFieldMandatory(): React.JSX.Element {
               'data-testid': 'custom-demo-dialog-mandatory-yes-radio',
             } as any
           }
+          disabled={isFeatureDisabled}
         />
       </RadioGroup>
     </DataFieldSection>

--- a/src/components/CredentialRequestsEditor/components/DataFieldUserInput.tsx
+++ b/src/components/CredentialRequestsEditor/components/DataFieldUserInput.tsx
@@ -2,11 +2,15 @@ import { RadioGroup } from '@mui/material';
 import { useController } from 'react-hook-form';
 
 import { type CredentialRequestsEditorForm } from '../types/form';
+import { useCredentialRequestsEditor } from '../CredentialRequestsEditor.context';
 import { useCredentialRequestField } from '../contexts/CredentialRequestFieldContext';
 import { RadioOption } from './RadioOption';
 import { DataFieldSection } from './DataFieldSection';
 
 export function DataFieldUserInput(): React.JSX.Element {
+  const { features } = useCredentialRequestsEditor();
+  const isFeatureDisabled = features?.description?.disabled === true;
+
   const credentialRequestField = useCredentialRequestField();
   const allowUserInput = useController<CredentialRequestsEditorForm>({
     name: `${credentialRequestField?.path as any}.allowUserInput` as any,
@@ -22,10 +26,14 @@ export function DataFieldUserInput(): React.JSX.Element {
           <pre>{`{\n  allowUserInput?: boolean\n}`}</pre>
         </>
       }
+      sx={{
+        opacity: isFeatureDisabled ? 0.5 : 1,
+      }}
     >
       <RadioGroup
         value={allowUserInput.field.value}
         onChange={(_, value) => {
+          if (isFeatureDisabled) return;
           // Update form state
           allowUserInput.field.onChange({
             target: { value: value === 'true' },
@@ -43,6 +51,7 @@ export function DataFieldUserInput(): React.JSX.Element {
               'data-testid': 'custom-demo-dialog-user-input-yes-radio',
             } as any
           }
+          disabled={isFeatureDisabled}
         />
         <RadioOption
           value={false}
@@ -54,6 +63,7 @@ export function DataFieldUserInput(): React.JSX.Element {
               'data-testid': 'custom-demo-dialog-user-input-no-radio',
             } as any
           }
+          disabled={isFeatureDisabled}
         />
       </RadioGroup>
     </DataFieldSection>

--- a/src/stories/components/CredentialRequestsEditor.stories.tsx
+++ b/src/stories/components/CredentialRequestsEditor.stories.tsx
@@ -81,6 +81,15 @@ export const Default: Story = {
     schemas: {},
     onChange: fn() as any,
     features: {
+      allowUserInput: {
+        disabled: false,
+      },
+      description: {
+        disabled: false,
+      },
+      mandatory: {
+        disabled: false,
+      },
       multi: {
         disabled: false,
       },


### PR DESCRIPTION
## Summary
Allow to control description, mandatory and allowUserInput fields from CredentialRequest object.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- updated credentialRequestsEditor modules

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects