### PR TITLE
Revert "chore: remove github registry from publish action"

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,6 +59,8 @@ jobs:
         uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          access: public
+          registry: https://npm.pkg.github.com
 
       # ref: https://cli.github.com/manual/gh_release_delete
       - name: Delete the v tag


### PR DESCRIPTION
Reverting because I can still publish to the github registry and make the package public:

Reverts VerifiedInc/shared-ui-elements#27