### PR TITLE
fix: change phone validation to allow numbers from different countries

### DIFF
--- a/src/components/form/PhoneInput.tsx
+++ b/src/components/form/PhoneInput.tsx
@@ -3,7 +3,7 @@ import { type TextFieldProps } from '../TextField';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { getPhoneDataByFieldName } from '../../utils/phone';
 import { inputStyle } from './styles/input';
-import { phoneSchema } from '../../validations/phone.schema';
+import { StrictPhoneFragmentSchema } from '../../validations/fragments/phone';
 
 import { TextMaskCustom } from './TextMaskCustom';
 import CountrySelector from './CountrySelector';
@@ -88,7 +88,7 @@ export function PhoneInput({
   };
 
   const checkIsValidPhone = (phone: string): void => {
-    const validation = phoneSchema.safeParse(value);
+    const validation = StrictPhoneFragmentSchema.safeParse(value);
     if (validation.success) {
       onValidPhone?.(phone);
     }


### PR DESCRIPTION
## Summary
The validation was only validating us numbers. By using this fragment we could use different numbers if we wanted

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
<!---
List all non-trivial changes included in this PR. Bullet points are fine or the individual commits that make up this PR.
--->

## Testing
<!---
How did you test your changes? How might someone else test them?
--->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects