### PR TITLE
feat: make clear adornment optional in ssn input

### DIFF
--- a/src/components/form/SSNInput.tsx
+++ b/src/components/form/SSNInput.tsx
@@ -14,6 +14,7 @@ export interface SSNInputProps {
   label?: string;
   error?: boolean;
   helperText?: string;
+  shouldHaveCloseAdornment?: boolean;
 }
 
 /**
@@ -23,6 +24,7 @@ export interface SSNInputProps {
 export function SSNInput({
   onChange,
   label = 'Social Security number',
+  shouldHaveCloseAdornment = false,
   ...rest
 }: SSNInputProps): React.JSX.Element {
   // Arbitrary states to allow to empty input field.
@@ -84,7 +86,7 @@ export function SSNInput({
     InputProps: {
       inputComponent: TextMaskCustom as any,
 
-      endAdornment: (
+      endAdornment: !!shouldHaveCloseAdornment && (
         <DataFieldClearAdornment
           onClick={handleClear}
           handleClear={handleClear}

--- a/src/stories/components/form/SSNInput.stories.ts
+++ b/src/stories/components/form/SSNInput.stories.ts
@@ -14,14 +14,12 @@ const meta = {
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
   args: {
-    InputProps: {
-      name: 'ssn',
-      label: 'SSN',
-      error: false,
-      helperText: 'Helper text',
-    },
+    name: 'ssn',
+    label: 'SSN',
+    error: false,
+    helperText: 'Helper text',
+    shouldHaveCloseAdornment: false,
     onChange: fn(),
-    onClear: fn(),
   },
 };
 


### PR DESCRIPTION
## Summary
feat: make clear adornment optional in ssn input by adding a prop called shouldHaveCloseAdornment

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
also fixed ssn stories. It wasn't passing the proper args

## Testing
using stories

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects