### PR TITLE
fix: ssn was clearing first value sent to it when using react hook fo…

### DIFF
--- a/src/components/form/SSNInput.tsx
+++ b/src/components/form/SSNInput.tsx
@@ -41,11 +41,6 @@ export function SSNInput({
     onChange?.({ target: { value: '' } });
   };
 
-  // Clearing value first time when component is mounted, so it doesn't hold redacted value state.
-  useEffect(() => {
-    handleClear();
-  }, []);
-
   const textFieldStyle: TextStyles = {
     ...inputStyle,
     value,


### PR DESCRIPTION
…rm controlled input

## Summary
ssn was clearing first value sent to it when using react hook form controlled input

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
remove clear method called on the first load

## Testing
local in node modules

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects