### PR TITLE
fix: remove blur causing maximum call stack error, blur on full otp input

### DIFF
--- a/src/components/form/OTPInput.tsx
+++ b/src/components/form/OTPInput.tsx
@@ -140,10 +140,6 @@ function OTPInputComponent(
     const valuesString = values.join('');
     const firstEmptyInput = inputsRef.current[valuesString.length];
 
-    for (const input of inputsRef.current) {
-      input?.blur();
-    }
-
     firstEmptyInput?.focus();
     firstEmptyInput?.select();
   }, [values]);
@@ -165,6 +161,7 @@ function OTPInputComponent(
 
         // Calls onChange when all OTP fields are filled.
         if (newValueString.length === 6) {
+          inputsRef.current.forEach((input) => input?.blur());
           props.onChange?.({ target: { value: newValueString } });
         }
 


### PR DESCRIPTION
## Summary
Fix call stack error when blur event is called right before focus.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- updated otp input

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects