### PR TITLE
fix: remove persist option from Snackbar enqueue function

### DIFF
--- a/src/components/Snackbar/index.tsx
+++ b/src/components/Snackbar/index.tsx
@@ -71,7 +71,6 @@ export function useSnackbar(): {
     _enqueueSnackbar(message, {
       severity,
       variant: 'customAlertComponent',
-      persist: true,
       ...options,
     });
   };


### PR DESCRIPTION
## Summary
Remove persist option from Snackbar enqueue function, as this is not a valid option

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
<!---
List all non-trivial changes included in this PR. Bullet points are fine or the individual commits that make up this PR.
--->

## Testing
<!---
How did you test your changes? How might someone else test them?
--->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects