### PR TITLE
fix: add form control to input base to avoid bad setState

### DIFF
--- a/src/components/form/OTPInput.tsx
+++ b/src/components/form/OTPInput.tsx
@@ -20,6 +20,7 @@ import {
   type InputBaseProps,
   Typography,
   useTheme,
+  FormControl,
 } from '@mui/material';
 import { v4 as uuid } from 'uuid';
 
@@ -192,22 +193,24 @@ function OTPInputComponent(
     (startIndex: number) => {
       return new Array(3).fill(undefined).map((_, index) => {
         return (
-          <InputBase
-            key={ids.current[index + startIndex]}
-            inputRef={(input) =>
-              ((inputsRef.current[index + startIndex] as any) = input)
-            }
-            autoComplete='one-time-code'
-            autoFocus={index + startIndex === 0}
-            value={values[index + startIndex] || ''}
-            disabled={props.disabled}
-            onChange={handleChange}
-            onKeyUp={handleKeyUp}
-            onFocus={handleFocus}
-            onBlur={() => setIsFocused(false)}
-            {...inputProps}
-            data-testid={`otp-input-${index + startIndex}`}
-          />
+          // FormControl is required for InputBase to avoid bad setState in handleBlur event, and it is one per input.
+          <FormControl key={ids.current[index + startIndex]}>
+            <InputBase
+              inputRef={(input) =>
+                ((inputsRef.current[index + startIndex] as any) = input)
+              }
+              autoComplete='one-time-code'
+              autoFocus={index + startIndex === 0}
+              value={values[index + startIndex] || ''}
+              disabled={props.disabled}
+              onChange={handleChange}
+              onKeyUp={handleKeyUp}
+              onFocus={handleFocus}
+              onBlur={() => setIsFocused(false)}
+              {...inputProps}
+              data-testid={`otp-input-${index + startIndex}`}
+            />
+          </FormControl>
         );
       });
     },


### PR DESCRIPTION
## Summary
Fixes bad setState captured in the Dashboard project when pasting the OTP, causing a setState to blur the input in the MUI core package.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- updated OTPInput

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects