### PR TITLE
fix: add key prop to top react element renderer

### DIFF
--- a/src/components/chart/SeriesChartLegend/index.tsx
+++ b/src/components/chart/SeriesChartLegend/index.tsx
@@ -143,12 +143,8 @@ export function SeriesChartLegend(props: LegendProps): ReactElement {
     >
       <AnimatePresence>
         {payload?.map((entry) => (
-          <Grid2>
-            <EntryBlock
-              key={`item-${entry.value}`}
-              entry={entry}
-              payload={payload}
-            />
+          <Grid2 key={`item-${entry.value}`}>
+            <EntryBlock entry={entry} payload={payload} />
           </Grid2>
         ))}
       </AnimatePresence>


### PR DESCRIPTION
## Summary
Fixed renderer to have key prop at top react element.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- moved key prop up

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects