### PR TITLE
fix: change how chart displays each serie to an absolute area

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "3.4.5",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@verifiedinc-public/shared-ui-elements",
-      "version": "3.4.5",
+      "version": "3.5.0",
       "devDependencies": {
         "@chromatic-com/storybook": "^2.0.2",
         "@storybook/addon-essentials": "^8.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "3.4.5",
+  "version": "3.5.0",
   "description": "A set of UI components, utilities that is shareable with the core apps.",
   "private": false,
   "keywords": [],

--- a/src/components/chart/SeriesPercentageChart/index.tsx
+++ b/src/components/chart/SeriesPercentageChart/index.tsx
@@ -9,7 +9,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import Decimal from 'decimal.js';
-import { Box, type SxProps } from '@mui/material';
+import { Box, useTheme, type SxProps } from '@mui/material';
 
 import { formatDateMMYY, formatExtendedDate } from '../../../utils/date';
 
@@ -17,11 +17,12 @@ interface KeyValue {
   key: string;
   name: string;
   color: string;
+  isTotal?: boolean;
 }
 
 interface ChartDataPoint {
-  date: number;
-  [key: string]: number; // Allow dynamic key access
+  date: string;
+  [key: string]: string | number; // Allow both string and number values
 }
 
 interface SeriesChartData {
@@ -39,10 +40,10 @@ interface SeriesPercentageChartProps {
 interface FormattedChartData {
   date: string;
   total: number;
-  oneClickSuccess: number;
-  oneClickCreated: number;
-  oneClickCancelled: number;
-  [key: string]: string | number; // Allow dynamic key access
+  diff: number;
+  totalKey: string;
+  originalTotal: number;
+  [key: string]: string | number; // Allow both string and number values
 }
 
 const formatChartData = (
@@ -50,46 +51,90 @@ const formatChartData = (
   keyValues: KeyValue[],
 ): FormattedChartData[] => {
   // Create a map to store all unique dates
-  const dateMap = new Map<number, FormattedChartData>();
+  const dateMap = new Map<string, FormattedChartData>();
 
-  // Collect all unique dates from all series
+  // First pass: collect all data points
   data.forEach((series) => {
     series.chartData.forEach((point) => {
-      if (!dateMap.has(point.date)) {
+      const dateKey = new Date(point.date).getTime().toString();
+
+      if (!dateMap.has(dateKey)) {
         const entry: FormattedChartData = {
-          date: point.date.toString(),
+          date: dateKey,
           total: 0,
-          oneClickSuccess: 0,
-          oneClickCreated: 0,
-          oneClickCancelled: 0,
+          diff: 0,
+          totalKey: '',
+          originalTotal: 0,
         };
         // Initialize all keyValues with 0
         keyValues.forEach(({ key }) => {
           entry[key] = 0;
+          entry[`${key}_absolute`] = 0;
         });
-        dateMap.set(point.date, entry);
+        dateMap.set(dateKey, entry);
       }
 
       // Add the values for each key
       keyValues.forEach(({ key }) => {
         const currentEntry = dateMap.get(
-          point.date,
+          dateKey,
         ) as unknown as FormattedChartData;
-        currentEntry[key] = point[key] || 0;
+        const rawValue = point[key];
+        // Convert string values to numbers, handling empty strings and undefined
+        const value =
+          typeof rawValue === 'string'
+            ? rawValue.trim() === ''
+              ? 0
+              : parseInt(rawValue, 10)
+            : typeof rawValue === 'number'
+              ? rawValue
+              : 0;
+
+        // Store absolute value
+        currentEntry[`${key}_absolute`] = value;
+        // Initialize relative value (will be calculated later)
+        currentEntry[key] = 0;
       });
     });
   });
 
-  // Convert the map to array and add totals
+  // Convert the map to array and calculate percentages
   return Array.from(dateMap.values())
     .map((entry) => {
-      const total = keyValues.reduce(
-        (sum, { key }) => sum + ((entry[key] as number) || 0),
-        0,
-      );
+      const totalKey = keyValues.find((kv) => kv.isTotal)?.key;
+      const nonTotalKeys = keyValues
+        .filter((kv) => !kv.isTotal)
+        .map((kv) => kv.key);
+
+      if (!totalKey || nonTotalKeys.length === 0) return entry;
+
+      const totalValue = entry[`${totalKey}_absolute`] as number;
+
+      // Store original total
+      entry.originalTotal = totalValue;
+      entry.total = totalValue;
+
+      // Set total value to always be 100%
+      entry[totalKey] = 100;
+
+      // Calculate percentages for non-total fields
+      nonTotalKeys.forEach((key) => {
+        const absoluteValue = entry[`${key}_absolute`] as number;
+        const percentage =
+          totalValue > 0
+            ? new Decimal(absoluteValue.toString())
+                .div(totalValue)
+                .mul(100)
+                .toFixed(2, Decimal.ROUND_DOWN)
+            : '0.00';
+
+        // Store the percentage for the area chart
+        entry[key] = parseFloat(percentage);
+      });
+
       return {
         ...entry,
-        total,
+        totalKey,
       };
     })
     .sort((a, b) => parseInt(a.date) - parseInt(b.date));
@@ -98,6 +143,7 @@ const formatChartData = (
 export function SeriesPercentageChart(
   props: SeriesPercentageChartProps,
 ): ReactElement {
+  const theme = useTheme();
   const formattedData = useMemo(() => {
     if (!props.data) return [];
     return formatChartData(props.data, props.keyValues);
@@ -108,7 +154,6 @@ export function SeriesPercentageChart(
       <ResponsiveContainer width='100%' height='100%'>
         <AreaChart
           data={formattedData}
-          stackOffset='expand'
           width={500}
           height={300}
           margin={{
@@ -138,40 +183,61 @@ export function SeriesPercentageChart(
           <YAxis
             textAnchor='end'
             tickLine={false}
-            tickFormatter={(value) => `${(value * 100).toFixed(2)}%`}
+            tickFormatter={(value) => `${value.toFixed(2)}%`}
           />
           <Tooltip
-            formatter={(value, name, item) => {
-              const total = item.payload.total;
-              const percentage =
-                total === 0
-                  ? '0.00'
-                  : new Decimal(value.toString())
-                      .div(total)
-                      .mul(100)
-                      .toFixed(2, Decimal.ROUND_DOWN);
-
-              return [`${value.toString()} (${percentage}%)`, name];
-            }}
+            cursor={{ stroke: theme.palette.neutral.main, strokeWidth: 1 }}
             labelFormatter={(value) =>
               formatExtendedDate(value, {
                 timeZone: props.filter.timezone,
                 hour12: false,
               })
             }
+            formatter={(value, name, item) => {
+              const totalKey = item.payload.totalKey;
+              const dataKey = item.dataKey as string;
+              const isTotal = dataKey === totalKey;
+
+              // Get the absolute value for this specific key
+              const absoluteValue = item.payload[`${dataKey}_absolute`];
+              const total = item.payload.originalTotal;
+
+              // Calculate percentage
+              const percentage = !isTotal
+                ? total === 0
+                  ? '0.00'
+                  : new Decimal(absoluteValue.toString())
+                      .div(total)
+                      .mul(100)
+                      .toFixed(2, Decimal.ROUND_DOWN)
+                : null;
+
+              return [
+                percentage
+                  ? `${absoluteValue.toLocaleString()} (${percentage}%)`
+                  : `${absoluteValue.toLocaleString()} (TOTAL)`,
+                name,
+              ];
+            }}
           />
-          {props.keyValues.map((keyValue) => (
-            <Area
-              key={keyValue.key}
-              type='monotone'
-              dataKey={keyValue.key}
-              name={keyValue.name}
-              stackId='1'
-              stroke={keyValue.color}
-              fill={keyValue.color}
-              strokeWidth={2}
-            />
-          ))}
+          {props.keyValues
+            .sort((a, b) => {
+              if (a.isTotal) return -1;
+              if (b.isTotal) return 1;
+              return 0;
+            })
+            .map((keyValue) => (
+              <Area
+                key={keyValue.key}
+                type='monotone'
+                dataKey={keyValue.key}
+                name={keyValue.name}
+                stroke={keyValue.color}
+                fill={keyValue.color}
+                strokeWidth={2}
+                fillOpacity={0.6}
+              />
+            ))}
         </AreaChart>
       </ResponsiveContainer>
     </Box>

--- a/src/stories/components/chart/SeriesPercentageChart.stories.tsx
+++ b/src/stories/components/chart/SeriesPercentageChart.stories.tsx
@@ -49,8 +49,13 @@ const sampleData = [
 
 const keyValues = [
   { key: 'oneClickSuccess', name: 'Success', color: '#0DBC3D' },
-  { key: 'oneClickCreated', name: 'Created', color: '#fbbc05' },
-  { key: 'oneClickCancelled', name: 'Cancelled', color: '#808080' },
+  {
+    key: 'oneClickCreated',
+    name: 'Created',
+    color: '#808080',
+    isTotal: true,
+  },
+  { key: 'oneClickCancelled', name: 'Cancelled', color: '#fbbc05' },
 ];
 
 export const Default: Story = {


### PR DESCRIPTION
## Summary
Enhanced SeriesPercentageChart component to support total values and improved data visualization with better percentage calculations and tooltips.

[Ticket](<!-- link to ticket -->)

## Changes
- Added support for total values in series data through `isTotal` flag in KeyValue interface
- Improved data structure to handle both absolute values and percentages
- Enhanced tooltip formatting to show absolute values and percentages
- Fixed division by zero issues in percentage calculations
- Added proper type handling for string and number values in chart data
- Improved visual styling with:
  - Configurable fill opacity (0.6)
  - Theme-based cursor color
  - Removed stack offset for better data representation
- Restructured data processing to:
  - Calculate percentages based on total values
  - Store both absolute and relative values
  - Sort series with total values appearing first
  - Handle empty/invalid data gracefully

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects