### PR TITLE
feat: add simple bar chart

### DIFF
--- a/src/components/chart/SimpleBarChart/index.tsx
+++ b/src/components/chart/SimpleBarChart/index.tsx
@@ -1,0 +1,59 @@
+import { type ComponentProps, type ReactElement } from 'react';
+import { Box, useTheme, type SxProps } from '@mui/material';
+import {
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+interface SimpleBarChartProps {
+  data: Array<{ key: string; value: number }>;
+  color?: string;
+  xAxisProps?: ComponentProps<typeof XAxis>;
+  yAxisProps?: ComponentProps<typeof YAxis>;
+  sx?: SxProps;
+}
+
+export function SimpleBarChart({
+  data,
+  color,
+  xAxisProps,
+  yAxisProps,
+  sx,
+}: SimpleBarChartProps): ReactElement {
+  const theme = useTheme();
+
+  return (
+    <Box sx={{ width: '100%', height: '100%', ...sx }}>
+      <ResponsiveContainer>
+        <ComposedChart
+          data={data}
+          margin={{
+            top: 5,
+            right: 30,
+            left: 20,
+            bottom: 5,
+          }}
+        >
+          <CartesianGrid strokeDasharray='3 3' vertical={false} />
+          <XAxis
+            dataKey='key'
+            tickLine={false}
+            fontSize={12}
+            tickMargin={12}
+            {...xAxisProps}
+          />
+          <YAxis textAnchor='end' tickLine={false} {...yAxisProps} />
+          <Tooltip
+            cursor={{ stroke: theme.palette.neutral.main, strokeWidth: 1 }}
+          />
+          <Bar dataKey='value' fill={color} isAnimationActive={false} />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </Box>
+  );
+}

--- a/src/components/chart/index.ts
+++ b/src/components/chart/index.ts
@@ -2,3 +2,4 @@ export * from './SeriesChart';
 export * from './SeriesChartLegend';
 export * from './SeriesPercentageChart';
 export * from './BigNumber';
+export * from './SimpleBarChart';

--- a/src/stories/components/chart/SimpleBarChart.stories.tsx
+++ b/src/stories/components/chart/SimpleBarChart.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { SimpleBarChart } from '../../../components/chart';
+
+const meta = {
+  title: 'components/chart/SimpleBarChart',
+  component: SimpleBarChart,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SimpleBarChart>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockData = new Array(1000).fill(0).map((_, i) => ({
+  key: String(i + 1),
+  value: Math.floor(Math.random() * 100),
+}));
+
+export const Default: Story = {
+  args: {
+    data: mockData,
+    sx: {
+      width: 800,
+      height: 400,
+    },
+  },
+};
+
+export const CustomStyling: Story = {
+  args: {
+    data: mockData,
+    sx: {
+      width: 800,
+      height: 400,
+    },
+    xAxisProps: {
+      tickLine: false,
+    },
+    yAxisProps: {
+      tickLine: false,
+    },
+  },
+};


### PR DESCRIPTION
## Summary
Added a new SimpleBarChart component that provides a responsive and customizable bar chart implementation using Recharts. The component supports styling through MUI's sx prop and allows for axis customization.

[Ticket](<!-- link to ticket -->)

## Changes
- Created new [SimpleBarChart](cci:1://file:///Users/iagormoraes/Desktop/projects/UnumID/shared-ui-elements/src/components/chart/SimpleBarChart/index.tsx:20:0-58:1) component with the following features:
  - Responsive design that adapts to container size
  - Customizable bar colors
  - Configurable X and Y axis properties through props
  - Built with Recharts for smooth rendering
- Added Storybook documentation and examples
  - Default story showcasing basic usage
  - CustomStyling story demonstrating axis customization
- Updated chart barrel file to export the new component

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects