### PR TITLE
Serie bar chart support

### DIFF
--- a/src/components/chart/SimpleBarChart/index.tsx
+++ b/src/components/chart/SimpleBarChart/index.tsx
@@ -38,10 +38,12 @@ export function SimpleBarChart({
 }: SimpleBarChartProps): ReactElement {
   const theme = useTheme();
 
-  const filterOnlyBack = (line: ComponentProps<typeof ReferenceLine>) =>
-    !line.isFront;
-  const filterOnlyFront = (line: ComponentProps<typeof ReferenceLine>) =>
-    line.isFront;
+  const filterOnlyBack = (
+    line: ComponentProps<typeof ReferenceLine>,
+  ): boolean => !line.isFront;
+  const filterOnlyFront = (
+    line: ComponentProps<typeof ReferenceLine>,
+  ): boolean => line.isFront;
 
   return (
     <Box sx={{ width: '100%', height: '100%', ...sx }}>

--- a/src/components/chart/SimpleBarChart/index.tsx
+++ b/src/components/chart/SimpleBarChart/index.tsx
@@ -11,9 +11,16 @@ import {
   YAxis,
 } from 'recharts';
 
-interface SimpleBarChartProps {
-  data: Array<{ key: string; value: number }>;
+interface Series {
+  key: string;
+  dataKey: string;
   color?: string;
+}
+
+interface SimpleBarChartProps {
+  data: Array<Record<string, number | string>>;
+  series: Series[];
+  xAxisDataKey: string;
   xAxisProps?: ComponentProps<typeof XAxis>;
   yAxisProps?: ComponentProps<typeof YAxis>;
   referenceLines?: Array<ComponentProps<typeof ReferenceLine>>;
@@ -22,13 +29,19 @@ interface SimpleBarChartProps {
 
 export function SimpleBarChart({
   data,
-  color,
+  series,
+  xAxisDataKey,
   xAxisProps,
   yAxisProps,
   referenceLines,
   sx,
 }: SimpleBarChartProps): ReactElement {
   const theme = useTheme();
+
+  const filterOnlyBack = (line: ComponentProps<typeof ReferenceLine>) =>
+    !line.isFront;
+  const filterOnlyFront = (line: ComponentProps<typeof ReferenceLine>) =>
+    line.isFront;
 
   return (
     <Box sx={{ width: '100%', height: '100%', ...sx }}>
@@ -44,7 +57,7 @@ export function SimpleBarChart({
         >
           <CartesianGrid strokeDasharray='3 3' vertical={false} />
           <XAxis
-            dataKey='key'
+            dataKey={xAxisDataKey}
             tickLine={false}
             fontSize={12}
             tickMargin={12}
@@ -54,10 +67,26 @@ export function SimpleBarChart({
           <Tooltip
             cursor={{ stroke: theme.palette.neutral.main, strokeWidth: 1 }}
           />
-          {referenceLines?.map((line, index) => (
-            <ReferenceLine key={index} {...(line as any)} />
+          {referenceLines
+            ?.filter(filterOnlyBack)
+            .map((line, index) => (
+              <ReferenceLine key={index} {...(line as any)} />
+            ))}
+          {series.map((serie) => (
+            <Bar
+              key={serie.key}
+              name={serie.key}
+              dataKey={serie.dataKey}
+              fill={serie.color}
+              stackId='stack'
+              isAnimationActive={false}
+            />
           ))}
-          <Bar dataKey='value' fill={color} isAnimationActive={false} />
+          {referenceLines
+            ?.filter(filterOnlyFront)
+            .map((line, index) => (
+              <ReferenceLine key={index} {...(line as any)} />
+            ))}
         </ComposedChart>
       </ResponsiveContainer>
     </Box>

--- a/src/components/chart/SimpleBarChart/index.tsx
+++ b/src/components/chart/SimpleBarChart/index.tsx
@@ -4,6 +4,7 @@ import {
   Bar,
   CartesianGrid,
   ComposedChart,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -15,6 +16,7 @@ interface SimpleBarChartProps {
   color?: string;
   xAxisProps?: ComponentProps<typeof XAxis>;
   yAxisProps?: ComponentProps<typeof YAxis>;
+  referenceLines?: Array<ComponentProps<typeof ReferenceLine>>;
   sx?: SxProps;
 }
 
@@ -23,6 +25,7 @@ export function SimpleBarChart({
   color,
   xAxisProps,
   yAxisProps,
+  referenceLines,
   sx,
 }: SimpleBarChartProps): ReactElement {
   const theme = useTheme();
@@ -51,6 +54,9 @@ export function SimpleBarChart({
           <Tooltip
             cursor={{ stroke: theme.palette.neutral.main, strokeWidth: 1 }}
           />
+          {referenceLines?.map((line, index) => (
+            <ReferenceLine key={index} {...(line as any)} />
+          ))}
           <Bar dataKey='value' fill={color} isAnimationActive={false} />
         </ComposedChart>
       </ResponsiveContainer>

--- a/src/stories/components/chart/SimpleBarChart.stories.tsx
+++ b/src/stories/components/chart/SimpleBarChart.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { SimpleBarChart } from '../../../components/chart';
+import { Label } from 'recharts';
 
 const meta = {
   title: 'components/chart/SimpleBarChart',
@@ -41,6 +42,27 @@ export const CustomStyling: Story = {
     },
     yAxisProps: {
       tickLine: false,
+      domain: [0, 'dataMax + 25'],
     },
+    referenceLines: [
+      {
+        x: '1',
+        stroke: 'green',
+        strokeDasharray: '3 3',
+        label: <Label value='Allow' position='insideTopLeft' />,
+      },
+      {
+        x: '300',
+        stroke: 'yellow',
+        strokeDasharray: '3 3',
+        label: <Label value='Flag' position='insideTopLeft' />,
+      },
+      {
+        x: '600',
+        stroke: 'red',
+        strokeDasharray: '3 3',
+        label: <Label value='Block' position='insideTopLeft' />,
+      },
+    ],
   },
 };

--- a/src/stories/components/chart/SimpleBarChart.stories.tsx
+++ b/src/stories/components/chart/SimpleBarChart.stories.tsx
@@ -15,14 +15,49 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const mockData = new Array(1000).fill(0).map((_, i) => ({
-  key: String(i + 1),
-  value: Math.floor(Math.random() * 100),
-}));
+const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'];
+
+const generateRandomData = () => {
+  return new Array(10).fill(0).map((_, i) => ({
+    month: i + 1,
+    series1: Math.floor(Math.random() * 100),
+    series2: Math.floor(Math.random() * 100),
+    series3: Math.floor(Math.random() * 100),
+  }));
+};
+
+const defaultSeries = [
+  { key: 'Series 1', dataKey: 'series1', color: '#1f77b4' },
+  { key: 'Series 2', dataKey: 'series2', color: '#ff7f0e' },
+  { key: 'Series 3', dataKey: 'series3', color: '#ddbc23' },
+];
+
+const mockData = generateRandomData();
 
 export const Default: Story = {
   args: {
     data: mockData,
+    series: defaultSeries,
+    xAxisDataKey: 'month',
+    sx: {
+      width: 800,
+      height: 400,
+    },
+  },
+};
+
+const threeSeriesData = generateRandomData();
+const threeSeries = [
+  { key: 'Series 1', dataKey: 'series1', color: '#1f77b4' },
+  { key: 'Series 2', dataKey: 'series2', color: '#ff7f0e' },
+  { key: 'Series 3', dataKey: 'series3', color: '#2ca02c' },
+];
+
+export const ThreeSeries: Story = {
+  args: {
+    data: threeSeriesData,
+    series: threeSeries,
+    xAxisDataKey: 'month',
     sx: {
       width: 800,
       height: 400,
@@ -33,6 +68,8 @@ export const Default: Story = {
 export const CustomStyling: Story = {
   args: {
     data: mockData,
+    series: defaultSeries,
+    xAxisDataKey: 'month',
     sx: {
       width: 800,
       height: 400,
@@ -46,22 +83,11 @@ export const CustomStyling: Story = {
     },
     referenceLines: [
       {
-        x: '1',
-        stroke: 'green',
-        strokeDasharray: '3 3',
-        label: <Label value='Allow' position='insideTopLeft' />,
-      },
-      {
-        x: '300',
-        stroke: 'yellow',
-        strokeDasharray: '3 3',
-        label: <Label value='Flag' position='insideTopLeft' />,
-      },
-      {
-        x: '600',
+        y: 150,
         stroke: 'red',
         strokeDasharray: '3 3',
-        label: <Label value='Block' position='insideTopLeft' />,
+        label: <Label value='Threshold' position='insideBottomRight' />,
+        isFront: true,
       },
     ],
   },


### PR DESCRIPTION
## Summary
Added support for multiple series in SimpleBarChart component with stacked bars functionality and enhanced reference lines with front/back positioning capability.

[Ticket](<!-- link to ticket -->)

## Changes
- Added support for multiple data series in SimpleBarChart component with automatic stacking
  - Each series can have its own color and data key
  - Bars from different series are automatically stacked when rendered
- Enhanced reference lines functionality
  - Added ability to position reference lines in front or behind bars using `isFront` property
  - Split reference lines rendering to support proper z-index layering
- Updated storybook examples to demonstrate new features
  - Added examples with multiple series
  - Showcased reference lines positioning capabilities

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects