### PR TITLE
add tooltip props

### DIFF
--- a/src/components/chart/SimpleBarChart/index.tsx
+++ b/src/components/chart/SimpleBarChart/index.tsx
@@ -11,6 +11,12 @@ import {
   YAxis,
 } from 'recharts';
 
+import {
+  chartDefaultProps,
+  xAxisDefaultProps,
+  yAxisDefaultProps,
+} from '../shared';
+
 interface Series {
   key: string;
   dataKey: string;
@@ -20,9 +26,10 @@ interface Series {
 interface SimpleBarChartProps {
   data: Array<Record<string, number | string>>;
   series: Series[];
-  xAxisDataKey: string;
-  xAxisProps?: ComponentProps<typeof XAxis>;
-  yAxisProps?: ComponentProps<typeof YAxis>;
+  xAxis?: ComponentProps<typeof XAxis>;
+  yAxis?: ComponentProps<typeof YAxis>;
+  tooltip?: ComponentProps<typeof Tooltip>;
+  bar?: ComponentProps<typeof Bar>;
   referenceLines?: Array<ComponentProps<typeof ReferenceLine>>;
   sx?: SxProps;
 }
@@ -30,9 +37,10 @@ interface SimpleBarChartProps {
 export function SimpleBarChart({
   data,
   series,
-  xAxisDataKey,
-  xAxisProps,
-  yAxisProps,
+  xAxis,
+  yAxis,
+  tooltip,
+  bar,
   referenceLines,
   sx,
 }: SimpleBarChartProps): ReactElement {
@@ -48,26 +56,13 @@ export function SimpleBarChart({
   return (
     <Box sx={{ width: '100%', height: '100%', ...sx }}>
       <ResponsiveContainer>
-        <ComposedChart
-          data={data}
-          margin={{
-            top: 5,
-            right: 30,
-            left: 20,
-            bottom: 5,
-          }}
-        >
+        <ComposedChart data={data} {...chartDefaultProps}>
           <CartesianGrid strokeDasharray='3 3' vertical={false} />
-          <XAxis
-            dataKey={xAxisDataKey}
-            tickLine={false}
-            fontSize={12}
-            tickMargin={12}
-            {...xAxisProps}
-          />
-          <YAxis textAnchor='end' tickLine={false} {...yAxisProps} />
+          <XAxis {...xAxisDefaultProps} {...xAxis} />
+          <YAxis {...yAxisDefaultProps} {...yAxis} />
           <Tooltip
             cursor={{ stroke: theme.palette.neutral.main, strokeWidth: 1 }}
+            {...tooltip}
           />
           {referenceLines
             ?.filter(filterOnlyBack)
@@ -82,6 +77,7 @@ export function SimpleBarChart({
               fill={serie.color}
               stackId='stack'
               isAnimationActive={false}
+              {...(bar as any)}
             />
           ))}
           {referenceLines

--- a/src/components/chart/shared.ts
+++ b/src/components/chart/shared.ts
@@ -1,0 +1,19 @@
+export const chartDefaultProps = {
+  margin: {
+    top: 5,
+    right: 30,
+    left: 20,
+    bottom: 5,
+  },
+};
+
+export const xAxisDefaultProps = {
+  tickLine: false,
+  fontSize: 12,
+  tickMargin: 12,
+};
+
+export const yAxisDefaultProps = {
+  textAnchor: 'end',
+  tickLine: false,
+};

--- a/src/stories/components/chart/SimpleBarChart.stories.tsx
+++ b/src/stories/components/chart/SimpleBarChart.stories.tsx
@@ -36,9 +36,23 @@ const mockData = generateRandomData();
 
 export const Default: Story = {
   args: {
-    data: mockData,
-    series: defaultSeries,
-    xAxisDataKey: 'month',
+    data: [
+      { key: 'OCE000', OCE000: 100 },
+      { key: 'OCE001', OCE001: 200 },
+    ],
+    series: [
+      {
+        key: 'OCE000',
+        dataKey: 'OCE000',
+        color: 'red',
+      },
+      {
+        key: 'OCE001',
+        dataKey: 'OCE001',
+        color: 'red',
+      },
+    ],
+    xAxisDataKey: 'key',
     sx: {
       width: 800,
       height: 400,

--- a/src/stories/components/chart/SimpleBarChart.stories.tsx
+++ b/src/stories/components/chart/SimpleBarChart.stories.tsx
@@ -52,7 +52,12 @@ export const Default: Story = {
         color: 'red',
       },
     ],
-    xAxisDataKey: 'key',
+    xAxis: {
+      dataKey: 'key',
+    },
+    tooltip: {
+      labelFormatter: (value) => 'Value for:',
+    },
     sx: {
       width: 800,
       height: 400,
@@ -71,7 +76,9 @@ export const ThreeSeries: Story = {
   args: {
     data: threeSeriesData,
     series: threeSeries,
-    xAxisDataKey: 'month',
+    xAxis: {
+      dataKey: 'month',
+    },
     sx: {
       width: 800,
       height: 400,
@@ -83,15 +90,15 @@ export const CustomStyling: Story = {
   args: {
     data: mockData,
     series: defaultSeries,
-    xAxisDataKey: 'month',
     sx: {
       width: 800,
       height: 400,
     },
-    xAxisProps: {
+    xAxis: {
       tickLine: false,
+      dataKey: 'month',
     },
-    yAxisProps: {
+    yAxis: {
       tickLine: false,
       domain: [0, 'dataMax + 25'],
     },


### PR DESCRIPTION
## Summary
Enhanced SimpleBarChart component with improved props structure, shared default props, and added more control over tooltip and axis customization. This change improves component reusability and customization capabilities.

[Ticket](<!-- link to ticket -->)

## Changes
- Refactored SimpleBarChart props structure for better consistency
  - Renamed `xAxisProps` and `yAxisProps` to `xAxis` and `yAxis` respectively
  - Moved `xAxisDataKey` into `xAxis.dataKey` for better prop organization
  - Added new props for tooltip and bar customization
- Created shared default props for chart components
  - Added [shared.ts](cci:7://file:///Users/iagormoraes/Desktop/projects/UnumID/shared-ui-elements/src/components/chart/shared.ts:0:0-0:0) with default props for chart, x-axis, and y-axis
  - Extracted common styling into reusable configurations
  - Improved maintainability by centralizing default values
- Updated stories to demonstrate new props structure
  - Added example with custom tooltip formatting
  - Updated existing examples to use new prop names
  - Added more realistic data examples

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects