### PR TITLE
feat: add error code chart

### DIFF
--- a/src/components/chart/ErrorCodesChart/index.tsx
+++ b/src/components/chart/ErrorCodesChart/index.tsx
@@ -1,0 +1,87 @@
+import { type ReactElement } from 'react';
+import { useTheme, type SxProps } from '@mui/material';
+import { Label } from 'recharts';
+
+import { SimpleBarChart } from '../SimpleBarChart';
+
+/**
+ * Props for the ErrorCodesChart component
+ */
+interface ErrorCodesChartProps {
+  /**
+   * Data object containing error codes and their occurrence counts.
+   * The data should follow the structure: Record<string, number>
+   * Example: { OCE000: 150, OCE001: 75 }
+   */
+  data: Record<string, number> | undefined;
+  /**
+   * MUI System props object for custom styling of the chart container
+   */
+  sx?: SxProps;
+}
+
+/**
+ * A bar chart component that visualizes error code occurrences.
+ *
+ * The chart displays error codes on the x-axis and their counts on the y-axis.
+ * It includes a reference line at y=100 to indicate an unhealthy threshold.
+ * Each error code is represented by a bar with a light error color from the theme.
+ *
+ * @example
+ * ```tsx
+ * <ErrorCodesChart
+ *   data={{
+ *     OCE000: 150,
+ *     OCE001: 75
+ *   }}
+ *   sx={{ width: 800, height: 400 }}
+ * />
+ * ```
+ */
+export function ErrorCodesChart({
+  data,
+  sx,
+}: ErrorCodesChartProps): ReactElement {
+  const theme = useTheme();
+
+  const _data = Object.entries(data ?? {}).map(([errorCode, value]) => ({
+    key: errorCode,
+    [errorCode]: value,
+  }));
+
+  const series = _data.map(({ key }) => ({
+    key,
+    dataKey: key,
+    color: theme.palette.error.light,
+  }));
+
+  return (
+    <SimpleBarChart
+      sx={sx}
+      data={_data}
+      series={series}
+      xAxis={{
+        tickLine: false,
+        dataKey: 'key',
+      }}
+      yAxis={{
+        tickLine: false,
+        domain: [0, 'dataMax + 100'],
+      }}
+      tooltip={{
+        labelFormatter: (value) => 'Total',
+      }}
+      referenceLines={[
+        {
+          y: 100,
+          stroke: theme.palette.error.dark,
+          strokeDasharray: '3 3',
+          label: (
+            <Label value='Unhealthy threshold' position='insideBottomRight' />
+          ),
+          isFront: true,
+        },
+      ]}
+    />
+  );
+}

--- a/src/components/chart/index.ts
+++ b/src/components/chart/index.ts
@@ -3,3 +3,4 @@ export * from './SeriesChartLegend';
 export * from './SeriesPercentageChart';
 export * from './BigNumber';
 export * from './SimpleBarChart';
+export * from './ErrorCodesChart';

--- a/src/stories/components/chart/ErrorCodesChart.stories.tsx
+++ b/src/stories/components/chart/ErrorCodesChart.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ErrorCodesChart } from '../../../components/chart';
+
+const meta = {
+  title: 'components/chart/ErrorCodesChart',
+  component: ErrorCodesChart,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ErrorCodesChart>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockData = {
+  OCE000: 150,
+  OCE001: 75,
+  OCE002: 200,
+  OCE003: 50,
+};
+
+export const Default: Story = {
+  args: {
+    data: mockData,
+    sx: {
+      width: 800,
+      height: 400,
+    },
+  },
+};
+
+export const NoData: Story = {
+  args: {
+    data: undefined,
+    sx: {
+      width: 800,
+      height: 400,
+    },
+  },
+};
+
+export const SingleError: Story = {
+  args: {
+    data: {
+      OCE000: 300,
+    },
+    sx: {
+      width: 800,
+      height: 400,
+    },
+  },
+};


### PR DESCRIPTION
## Summary
Added a new ErrorCodesChart component that visualizes error code occurrences using a bar chart, with an unhealthy threshold reference line and customizable styling options.

[Ticket](<!-- link to ticket -->)

## Changes
- Created new [ErrorCodesChart](cci:1://file:///Users/iagormoraes/Desktop/projects/UnumID/shared-ui-elements/src/components/chart/ErrorCodesChart/index.tsx:22:0-92:1) component that displays error code frequencies
- Added comprehensive documentation and TypeScript types for the component
- Created Storybook stories with multiple variants (Default, NoData, SingleError)
- Component features:
  - Dynamic bar generation based on error code data
  - Unhealthy threshold reference line at y=100
  - Custom styling through MUI's sx prop
  - Tooltip customization showing "Total" as label
  - Theme-based error color for bars
- Exported component through the chart index barrel file

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects