### PR TITLE
feat: add risk score bar chart

### DIFF
--- a/src/components/chart/RiskScoreBarChart/index.tsx
+++ b/src/components/chart/RiskScoreBarChart/index.tsx
@@ -1,0 +1,91 @@
+import { type ReactElement } from 'react';
+import { useTheme, type SxProps } from '@mui/material';
+
+import { SimpleBarChart } from '../SimpleBarChart';
+
+interface RiskScoreBarChartProps {
+  data: Array<Record<number, number>>;
+  sx?: SxProps;
+}
+
+export function RiskScoreBarChart({
+  data,
+  sx,
+}: RiskScoreBarChartProps): ReactElement {
+  const theme = useTheme();
+  const transformData = (
+    inputData: Array<Record<number, number>>,
+  ): Array<Record<number, number>> => {
+    const aggregatedData: Record<number, number> = {};
+
+    // Aggregate all scores
+    inputData.forEach((score) => {
+      Object.entries(score).forEach(([key, value]) => {
+        const numKey = parseInt(key);
+        if (numKey <= 1000) {
+          aggregatedData[numKey] = (aggregatedData[numKey] || 0) + value;
+        }
+      });
+    });
+
+    // Create array from 0 to 1000 and map values from aggregatedData
+    return Array.from({ length: 1001 }, (_, index) => ({
+      key: index.toString(),
+      value: aggregatedData[index] || 0,
+    }));
+  };
+
+  const transformedData = transformData(data);
+
+  const series = [
+    {
+      key: 'Risk Score',
+      dataKey: 'value',
+      color: theme.palette.error.main,
+    },
+  ];
+
+  return (
+    <SimpleBarChart
+      data={transformedData}
+      series={series}
+      sx={sx}
+      yAxis={{
+        label: { value: 'Count', angle: -90, position: 'insideLeft' },
+        domain: [0, 'dataMax + 10'],
+      }}
+      xAxis={{
+        domain: [0, 'dataMax'],
+        interval: 'preserveStartEnd',
+      }}
+      tooltip={{
+        labelFormatter: () => 'Risk Score',
+        formatter: (value, _, props) => {
+          return [value, props.payload.key];
+        },
+      }}
+      referenceAreas={[
+        {
+          x1: 0,
+          x2: 299,
+          fill: '#ffffff00',
+          isFront: false,
+          label: 'Allowed',
+        },
+        {
+          x1: 300,
+          x2: 600,
+          fill: theme.palette.warning.light,
+          isFront: false,
+          label: 'Flagged',
+        },
+        {
+          x1: 600,
+          fill: theme.palette.error.light,
+          isFront: false,
+          label: 'Blocked',
+        },
+      ]}
+    />
+  );
+}

--- a/src/components/chart/SimpleBarChart/index.tsx
+++ b/src/components/chart/SimpleBarChart/index.tsx
@@ -4,6 +4,7 @@ import {
   Bar,
   CartesianGrid,
   ComposedChart,
+  ReferenceArea,
   ReferenceLine,
   ResponsiveContainer,
   Tooltip,
@@ -31,6 +32,7 @@ interface SimpleBarChartProps {
   tooltip?: ComponentProps<typeof Tooltip>;
   bar?: ComponentProps<typeof Bar>;
   referenceLines?: Array<ComponentProps<typeof ReferenceLine>>;
+  referenceAreas?: Array<ComponentProps<typeof ReferenceArea>>;
   sx?: SxProps;
 }
 
@@ -42,16 +44,13 @@ export function SimpleBarChart({
   tooltip,
   bar,
   referenceLines,
+  referenceAreas,
   sx,
 }: SimpleBarChartProps): ReactElement {
   const theme = useTheme();
 
-  const filterOnlyBack = (
-    line: ComponentProps<typeof ReferenceLine>,
-  ): boolean => !line.isFront;
-  const filterOnlyFront = (
-    line: ComponentProps<typeof ReferenceLine>,
-  ): boolean => !!line.isFront;
+  const filterOnlyBack = (reference: any): boolean => !reference.isFront;
+  const filterOnlyFront = (reference: any): boolean => !!reference.isFront;
 
   return (
     <Box sx={{ width: '100%', height: '100%', ...sx }}>
@@ -66,8 +65,13 @@ export function SimpleBarChart({
           />
           {referenceLines
             ?.filter(filterOnlyBack)
-            .map((line, index) => (
-              <ReferenceLine key={index} {...(line as any)} />
+            .map((line) => (
+              <ReferenceLine key={JSON.stringify(line)} {...(line as any)} />
+            ))}
+          {referenceAreas
+            ?.filter(filterOnlyBack)
+            .map((area) => (
+              <ReferenceArea key={JSON.stringify(area)} {...(area as any)} />
             ))}
           {series.map((serie) => (
             <Bar
@@ -82,8 +86,13 @@ export function SimpleBarChart({
           ))}
           {referenceLines
             ?.filter(filterOnlyFront)
-            .map((line, index) => (
-              <ReferenceLine key={index} {...(line as any)} />
+            .map((line) => (
+              <ReferenceLine key={JSON.stringify(line)} {...(line as any)} />
+            ))}
+          {referenceAreas
+            ?.filter(filterOnlyFront)
+            .map((area) => (
+              <ReferenceArea key={JSON.stringify(area)} {...(area as any)} />
             ))}
         </ComposedChart>
       </ResponsiveContainer>

--- a/src/stories/components/chart/RiskScoreBarChart.stories.tsx
+++ b/src/stories/components/chart/RiskScoreBarChart.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { RiskScoreBarChart } from '../../../components/chart/RiskScoreBarChart';
+
+const meta = {
+  title: 'components/chart/RiskScoreBarChart',
+  component: RiskScoreBarChart,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof RiskScoreBarChart>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    data: [
+      {
+        0: 10,
+        1: 12,
+        2: 8,
+        500: 5,
+        1000: 3,
+      },
+      {
+        0: 5,
+        1: 8,
+        2: 15,
+      },
+    ],
+    sx: {
+      width: 800,
+      height: 400,
+    },
+  },
+};


### PR DESCRIPTION
## Summary
Created RiskScoreBarChart component that displays risk scores from 0 to 1000 with visual indicators for Allowed (0-299), Flagged (300-600), and Blocked (600+) ranges. The component aggregates score data and displays it using SimpleBarChart with appropriate styling and tooltips.

[Ticket](<!-- link to ticket -->)

## Changes
- Created new RiskScoreBarChart component that:
  - Accepts an array of objects containing risk score counts
  - Aggregates scores and displays them in a bar chart format
  - Shows full range from 0 to 1000 with appropriate scaling
  - Uses theme colors for bars and reference areas
- Enhanced SimpleBarChart component to support ReferenceArea elements
- Added visual indicators for risk ranges:
  - 0-299: Allowed (transparent)
  - 300-600: Flagged (warning light)
  - 600+: Blocked (error light)
- Improved tooltip formatting to show both score value and count
- Added domain constraints and interval preservation for better visualization

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects