### PR TITLE
fix: replace json stringify with label uniqueness falling back to index

### DIFF
--- a/src/components/chart/SimpleBarChart/index.tsx
+++ b/src/components/chart/SimpleBarChart/index.tsx
@@ -65,13 +65,13 @@ export function SimpleBarChart({
           />
           {referenceLines
             ?.filter(filterOnlyBack)
-            .map((line) => (
-              <ReferenceLine key={JSON.stringify(line)} {...(line as any)} />
+            .map((line, index) => (
+              <ReferenceLine key={line.label ?? index} {...(line as any)} />
             ))}
           {referenceAreas
             ?.filter(filterOnlyBack)
-            .map((area) => (
-              <ReferenceArea key={JSON.stringify(area)} {...(area as any)} />
+            .map((area, index) => (
+              <ReferenceArea key={area.label ?? index} {...(area as any)} />
             ))}
           {series.map((serie) => (
             <Bar
@@ -86,13 +86,13 @@ export function SimpleBarChart({
           ))}
           {referenceLines
             ?.filter(filterOnlyFront)
-            .map((line) => (
-              <ReferenceLine key={JSON.stringify(line)} {...(line as any)} />
+            .map((line, index) => (
+              <ReferenceLine key={line.label ?? index} {...(line as any)} />
             ))}
           {referenceAreas
             ?.filter(filterOnlyFront)
-            .map((area) => (
-              <ReferenceArea key={JSON.stringify(area)} {...(area as any)} />
+            .map((area, index) => (
+              <ReferenceArea key={area.label ?? index} {...(area as any)} />
             ))}
         </ComposedChart>
       </ResponsiveContainer>


### PR DESCRIPTION
## Summary
Fixed circular reference issues in SimpleBarChart by improving key generation for reference elements.

[Ticket](<!-- link to ticket -->)

## Changes
- Updated key prop to avoid circular reference

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects