### PR TITLE
feat: add allActive prop display pie detail

### DIFF
--- a/src/components/chart/PieChart/index.tsx
+++ b/src/components/chart/PieChart/index.tsx
@@ -78,6 +78,11 @@ interface PieChartProps {
    * Optional props object for the Pie component
    */
   pie?: Partial<PieProps>;
+  /**
+   * Optional flag to show all shapes as active
+   * @default false
+   */
+  allActive?: boolean;
 }
 
 // Define fallback colors for each series if no color is provided
@@ -122,10 +127,12 @@ export function PieChart({
   needleVisible = false,
   needleValue,
   needleColor = '#aaa',
+  allActive = false,
 }: PieChartProps): ReactElement {
   const { innerRadius = 60, outerRadius = 100 } = pie ?? {};
   const theme = useTheme();
-  const [activeIndex, setActiveIndex] = useState<number | undefined>();
+  const [activeIndex, setActiveIndex] = useState<number | undefined>(undefined);
+
   const [hiddenItems, setHiddenItems] = useState<Set<string>>(new Set());
   const boxRef = useRef<HTMLDivElement>(null);
   const [boxDimensions, setBoxDimensions] = useState<DOMRectReadOnly | null>(
@@ -135,11 +142,15 @@ export function PieChart({
     useState<DOMRectReadOnly | null>(null);
 
   const onPieEnter = (_: any, index: number): void => {
-    setActiveIndex(index);
+    if (!allActive) {
+      setActiveIndex(index);
+    }
   };
 
   const onPieLeave = (): void => {
-    setActiveIndex(undefined);
+    if (!allActive) {
+      setActiveIndex(undefined);
+    }
   };
 
   const toggleDataPoint = (payload: Payload): void => {
@@ -244,13 +255,16 @@ export function PieChart({
             dataKey='value'
             innerRadius={innerRadius}
             outerRadius={outerRadius}
-            activeIndex={activeIndex}
+            activeIndex={
+              allActive ? filteredData.map((_, i) => i) : activeIndex
+            }
             activeShape={(props: any) =>
               renderActiveShape({
                 ...props,
                 valueText,
                 valuePercentage,
                 needleVisible,
+                allActive,
               })
             }
             paddingAngle={0}

--- a/src/components/chart/PieChart/renderActiveShape.tsx
+++ b/src/components/chart/PieChart/renderActiveShape.tsx
@@ -19,6 +19,7 @@ export const renderActiveShape = (props: any): ReactElement => {
     valuePercentage,
     needleVisible,
     customText,
+    allActive,
   } = props;
 
   // Calculate positions for the line and text
@@ -28,7 +29,7 @@ export const renderActiveShape = (props: any): ReactElement => {
   const sy = cy + (outerRadius + 5) * sin;
   const mx = cx + (outerRadius + 15) * cos;
   const my = cy + (outerRadius + 15) * sin;
-  const ex = mx + (cos >= 0 ? 1 : -1) * 15;
+  const ex = mx + (cos >= 0 ? 1 : -1) * 22;
   const ey = my;
   const textAnchor = cos >= 0 ? 'start' : 'end';
 
@@ -37,20 +38,20 @@ export const renderActiveShape = (props: any): ReactElement => {
     maximumFractionDigits: 0,
   });
 
+  const renderPayloadName = (): ReactElement | null => {
+    if (needleVisible) return null;
+    if (allActive) return null;
+
+    return (
+      <text x={cx} y={cy} dy={8} textAnchor='middle' fill='#333' fontSize={14}>
+        {payload.name}
+      </text>
+    );
+  };
+
   return (
     <g>
-      {!needleVisible && (
-        <text
-          x={cx}
-          y={cy}
-          dy={8}
-          textAnchor='middle'
-          fill='#333'
-          fontSize={14}
-        >
-          {payload.name}
-        </text>
-      )}
+      {renderPayloadName()}
       <Sector
         cx={cx}
         cy={cy}
@@ -76,7 +77,7 @@ export const renderActiveShape = (props: any): ReactElement => {
       />
       <circle cx={ex} cy={ey} r={2} fill={fill} stroke='none' />
       <text
-        x={ex + (cos >= 0 ? 1 : -1) * 8}
+        x={ex + (cos >= 0 ? 1 : -1) * 12}
         y={ey}
         textAnchor={textAnchor}
         fill='#333'
@@ -87,7 +88,7 @@ export const renderActiveShape = (props: any): ReactElement => {
       </text>
       {valuePercentage && (
         <text
-          x={ex + (cos >= 0 ? 1 : -1) * 8}
+          x={ex + (cos >= 0 ? 1 : -1) * 12}
           y={ey}
           dy={16}
           textAnchor={textAnchor}

--- a/src/components/chart/RiskScorePieChart/index.tsx
+++ b/src/components/chart/RiskScorePieChart/index.tsx
@@ -52,6 +52,7 @@ export function RiskScorePieChart({
       legendToggle
       needleValue={score}
       legendLabel={legendLabel}
+      allActive
       sx={sx}
     />
   );

--- a/src/stories/components/chart/PieChart.stories.tsx
+++ b/src/stories/components/chart/PieChart.stories.tsx
@@ -35,11 +35,12 @@ const themeColorData = [
 export const Default: Story = {
   args: {
     data: defaultData,
-    valueText: 'Avg. {{needleValue}} Points',
+    valueText: 'Avg. 200 Points',
     valuePercentage: false,
     legendToggle: true,
     needleVisible: true,
     needleValue: 200,
+    allActive: true,
     pie: {
       startAngle: 180,
       endAngle: 0,
@@ -83,12 +84,13 @@ export const DonutChart: Story = {
   },
 };
 
-export const SingleValue: Story = {
+export const AllActive: Story = {
   args: {
     data: [{ name: 'Allow', value: 1000, color: '#4CAF50' }],
     sx: {
       width: 500,
       height: 500,
     },
+    allActive: true,
   },
 };


### PR DESCRIPTION
## Summary
Added new `allActive` prop to PieChart component that enables displaying details for all pie slices simultaneously. This enhancement improves data visualization by allowing users to see all slice details at once without needing to hover over individual slices.

[Ticket](<!-- link to ticket -->)

## Changes
- Added new `allActive` prop to PieChart component interface
- Modified PieChart component to support displaying multiple active shapes simultaneously
- Updated renderActiveShape to handle multiple active states:
  - Added conditional rendering for center text to prevent overlapping
  - Adjusted label positioning and spacing for better readability
  - Added `allActive` prop to control center text visibility
- Updated RiskScorePieChart to use the new `allActive` prop by default

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects