### PR TITLE
fix: omit hidden slices info

### DIFF
--- a/src/components/chart/PieChart/index.tsx
+++ b/src/components/chart/PieChart/index.tsx
@@ -256,7 +256,9 @@ export function PieChart({
             innerRadius={innerRadius}
             outerRadius={outerRadius}
             activeIndex={
-              allActive ? filteredData.map((_, i) => i) : activeIndex
+              allActive
+                ? filteredData.filter((item) => item.value > 0).map((_, i) => i)
+                : activeIndex
             }
             activeShape={(props: any) =>
               renderActiveShape({


### PR DESCRIPTION
## Summary
Added new `allActive` prop to PieChart component that enables displaying details for all pie slices simultaneously, while properly handling hidden slices. This enhancement improves data visualization by allowing users to see all active slice details at once, excluding any hidden or zero-value slices.

[Ticket](<!-- link to ticket -->)

## Changes
- Added new `allActive` prop to PieChart component interface
- Modified PieChart component to support displaying multiple active shapes simultaneously:
  - Added filter to exclude zero-value slices from active indices
  - Updated renderActiveShape to handle multiple active states
  - Added conditional rendering for center text to prevent overlapping
  - Adjusted label positioning and spacing for better readability
- Updated RiskScorePieChart to use the new `allActive` prop by default

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects