### PR TITLE
fix: filter out if value is zero keeping index reference

### DIFF
--- a/src/components/chart/PieChart/index.tsx
+++ b/src/components/chart/PieChart/index.tsx
@@ -168,8 +168,9 @@ export function PieChart({
     });
   };
 
-  const filteredData = data.map((item) => ({
+  const filteredData = data.map((item, index) => ({
     ...item,
+    index,
     value: hiddenItems.has(item.name) ? 0 : item.value,
   }));
 
@@ -257,7 +258,9 @@ export function PieChart({
             outerRadius={outerRadius}
             activeIndex={
               allActive
-                ? filteredData.filter((item) => item.value > 0).map((_, i) => i)
+                ? filteredData
+                    .filter((item) => item.value > 0)
+                    .map((item) => item.index)
                 : activeIndex
             }
             activeShape={(props: any) =>


### PR DESCRIPTION
## Summary
Fixes allActive to correctly omit the info when some of the slices are not selected.

[Ticket](<!-- link to ticket -->)

## Changes
- Fixed `activeIndex` for `allActive`to keep index reference

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects