### PR TITLE
feat: Add reason code chart

### DIFF
--- a/src/components/chart/ReasonCodesChart/index.tsx
+++ b/src/components/chart/ReasonCodesChart/index.tsx
@@ -1,0 +1,93 @@
+import { type ReactElement } from 'react';
+import { useTheme, type SxProps } from '@mui/material';
+import { Label } from 'recharts';
+
+import { SimpleBarChart } from '../SimpleBarChart';
+
+/**
+ * Props for the ReasonCodesChart component
+ */
+interface ReasonCodesChartProps {
+  /**
+   * Data object containing reason codes and their occurrence counts.
+   * The data should follow the structure: Record<string, number>
+   * Example: { OCR001: 150, OCR002: 75 }
+   */
+  data: Record<string, number> | undefined;
+  /**
+   * Threshold value for the reference line
+   */
+  threshold?: number;
+  /**
+   * MUI System props object for custom styling of the chart container
+   */
+  sx?: SxProps;
+}
+
+/**
+ * A bar chart component that visualizes reason code occurrences.
+ *
+ * The chart displays reason codes on the x-axis and their counts on the y-axis.
+ * It includes a reference line at y=100 to indicate an unhealthy threshold.
+ * Each reason code is represented by a bar with a light warning color from the theme.
+ *
+ * @example
+ * ```tsx
+ * <ReasonCodesChart
+ *   data={{
+ *     OCR001: 150,
+ *     OCR002: 75
+ *   }}
+ *   threshold={200}
+ *   sx={{ width: 800, height: 400 }}
+ * />
+ * ```
+ */
+export function ReasonCodesChart({
+  data,
+  threshold = 100,
+  sx,
+}: ReasonCodesChartProps): ReactElement {
+  const theme = useTheme();
+
+  const _data = Object.entries(data ?? {}).map(([reasonCode, value]) => ({
+    key: reasonCode,
+    [reasonCode]: value,
+  }));
+
+  const series = _data.map(({ key }) => ({
+    key,
+    dataKey: key,
+    color: theme.palette.warning.light,
+  }));
+
+  return (
+    <SimpleBarChart
+      sx={sx}
+      data={_data}
+      series={series}
+      xAxis={{
+        tickLine: false,
+        dataKey: 'key',
+      }}
+      yAxis={{
+        tickLine: false,
+        domain: [0, `dataMax + ${threshold}`],
+      }}
+      tooltip={{
+        labelFormatter: (value) => 'Total',
+      }}
+      referenceLines={[
+        {
+          y: threshold,
+          stroke: theme.palette.error.dark,
+          strokeDasharray: '3 3',
+          label: (
+            <Label value='Unhealthy threshold' position='insideBottomRight' />
+          ),
+          isFront: true,
+        },
+      ]}
+    />
+  );
+}

--- a/src/components/chart/index.ts
+++ b/src/components/chart/index.ts
@@ -4,6 +4,7 @@ export * from './SeriesPercentageChart';
 export * from './BigNumber';
 export * from './SimpleBarChart';
 export * from './ErrorCodesChart';
+export * from './ReasonCodesChart';
 export * from './PieChart';
 export * from './RiskScorePieChart';
 export * from './RiskScoreBarChart';

--- a/src/stories/components/chart/ReasonCodesChart.stories.tsx
+++ b/src/stories/components/chart/ReasonCodesChart.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ReasonCodesChart } from '../../../components/chart';
+
+const meta = {
+  title: 'components/chart/ReasonCodesChart',
+  component: ReasonCodesChart,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ReasonCodesChart>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockData = {
+  OCR001: 150,
+  OCR002: 75,
+  OCR003: 200,
+  OCR004: 50,
+  OCR005: 125,
+  OCR006: 100,
+  OCR007: 80,
+  OCR008: 60,
+};
+
+export const Default: Story = {
+  args: {
+    data: mockData,
+    sx: {
+      width: 800,
+      height: 400,
+    },
+  },
+};
+
+export const NoData: Story = {
+  args: {
+    data: undefined,
+    sx: {
+      width: 800,
+      height: 400,
+    },
+  },
+};
+
+export const SingleReason: Story = {
+  args: {
+    data: {
+      OCR001: 300, // Document Verification Failed - Invalid or Unreadable Document
+    },
+    sx: {
+      width: 800,
+      height: 400,
+    },
+  },
+};


### PR DESCRIPTION
## Summary
Added a new ReasonCodesChart component based on the ErrorCodesChart to visualize reason code occurrences. The component uses OCR prefixed codes and maintains visual consistency with other chart components.

[Ticket](<!-- link to ticket -->)

## Changes
From commit [d21217c]:
- Created new ReasonCodesChart component using the same structure as ErrorCodesChart
- Added corresponding story with examples of different reason code scenarios
- Used OCR prefix for reason codes
- Implemented error color scheme for consistency with other charts
- Added component to the chart exports

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects