### PR TITLE
feat: make selectable credentials optional

### DIFF
--- a/src/components/form/OneClickForm/components/DataField/DataFieldCheckbox.tsx
+++ b/src/components/form/OneClickForm/components/DataField/DataFieldCheckbox.tsx
@@ -1,4 +1,6 @@
-import { Checkbox } from '@mui/material';
+import { Box, Checkbox } from '@mui/material';
+
+import { useOneClickFormOptions } from '../../contexts/one-click-form-options.context';
 
 import { isRequiredCredentialDisplayInfo } from '../CredentialsDisplay/utils';
 import { useCredentialsDisplayItem } from '../CredentialsDisplay/CredentialsDisplayItemContext';
@@ -10,6 +12,12 @@ import { useCredentialsDisplayItem } from '../CredentialsDisplay/CredentialsDisp
  */
 export function DataFieldCheckbox() {
   const {
+    options: {
+      features: { selectableCredentials },
+    },
+  } = useOneClickFormOptions();
+
+  const {
     credentialDisplayInfo,
     isChecked,
     isAllChecked,
@@ -19,6 +27,9 @@ export function DataFieldCheckbox() {
   const isRequired = isRequiredCredentialDisplayInfo({
     mandatory: credentialDisplayInfo.credentialRequest?.mandatory,
   });
+
+  // Do not render checkbox when selectableCredentials is disabled
+  if (!selectableCredentials) return <Box sx={{ mr: 1 }} />;
 
   return (
     <Checkbox

--- a/src/components/form/OneClickForm/contexts/one-click-form-options.context.tsx
+++ b/src/components/form/OneClickForm/contexts/one-click-form-options.context.tsx
@@ -1,6 +1,7 @@
 import { createContext, ReactNode, useContext } from 'react';
 
 type OneClickOptionFeatures = {
+  selectableCredentials?: boolean;
   phoneCredentialWhitelist?: string[];
   phoneCredentialRegexWhitelist?: string;
 };
@@ -45,8 +46,16 @@ export function useOneClickFormOptions() {
 export function OneClickFormOptionsProvider(
   props: OneClickFormOptionsProviderProps,
 ) {
+  const { selectableCredentials = true } = props.options.features;
   return (
-    <Context.Provider value={{ options: props.options }}>
+    <Context.Provider
+      value={{
+        options: {
+          ...props.options,
+          features: { ...props.options.features, selectableCredentials },
+        },
+      }}
+    >
       {props.children}
     </Context.Provider>
   );

--- a/src/stories/components/form/OneClickForm.stories.tsx
+++ b/src/stories/components/form/OneClickForm.stories.tsx
@@ -150,7 +150,7 @@ const mockData = {
         },
         {
           type: 'LastNameCredential',
-          mandatory: 'no',
+          mandatory: 'yes',
           allowUserInput: true,
         },
       ],
@@ -510,6 +510,7 @@ function Component({ data, schemas }: any) {
         credentialRequests={data.credentialRequests}
         options={{
           features: {
+            selectableCredentials: false,
             phoneCredentialWhitelist: [],
             phoneCredentialRegexWhitelist:
               '^\\+1[-.\\s]?0\\d{2}[-.\\s]?\\d{3}[-.\\s]?\\d{4}$',


### PR DESCRIPTION
## Summary
<!---
1-2 sentences summarizing the changes included in this PR
--->
Added support for optional selectable credentials in the OneClickForm component, enhancing flexibility in credential selection workflows.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
<!---
List all non-trivial changes included in this PR. Bullet points are fine or the individual commits that make up this PR.
--->
- **93a3f11**: Added functionality to make selectable credentials optional in the form
  - Updated OneClickForm component to handle optional selectable fields
  - Modified form validation logic to accommodate optional selections

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects