### PR TITLE
fix: refactor buildDataFieldValue to prevent child of child item schema to be included in the parent list

### DIFF
--- a/src/components/CredentialRequestsEditor/utils/buildDataFieldValue.ts
+++ b/src/components/CredentialRequestsEditor/utils/buildDataFieldValue.ts
@@ -8,49 +8,75 @@ const isComposed = (schema: unknown): schema is CompositeCredentialSchema =>
   Object.prototype.hasOwnProperty.call(schema || {}, 'anyOf') ||
   Object.prototype.hasOwnProperty.call(schema || {}, 'allOf');
 
-function extractTypes(
-  record: any,
-  result: string[] = [],
-  parentKeys: string[] = [],
-): string[] {
-  _.forOwn(record, (value, key) => {
-    // Check if the current key is $ref or $id and handle accordingly
-    if (key === '$ref' && typeof value === 'string') {
-      result.push(value);
-    } else if (
-      key === '$id' &&
-      typeof value === 'string' &&
-      _.some(parentKeys, (k) => ['allOf', 'anyOf', 'oneOf'].includes(k))
-    ) {
-      result.push(value);
-    }
+function extractTypes(record: any, parentId?: string): string[] {
+  const result: string[] = [];
 
-    // If the value is an object or array, recurse into it
-    if (_.isObject(value)) {
-      extractTypes(value, result, [...parentKeys, key]);
-    }
-  });
+  // Handle direct $id at current level (skip if it matches parent)
+  if (record.$id && typeof record.$id === 'string' && record.$id !== parentId) {
+    result.push(record.$id);
+  }
 
-  return result;
+  // Handle direct $ref at current level
+  if (record.$ref && typeof record.$ref === 'string') {
+    result.push(record.$ref);
+    return result;
+  }
+
+  // Process anyOf array - only process direct children
+  if (Array.isArray(record.anyOf)) {
+    record.anyOf.forEach((schema: any) => {
+      if (schema && typeof schema === 'object') {
+        // If schema has $id, collect it but don't traverse deeper
+        if (schema.$id && typeof schema.$id === 'string') {
+          result.push(schema.$id);
+        }
+        // If schema has $ref, collect it
+        else if (schema.$ref && typeof schema.$ref === 'string') {
+          result.push(schema.$ref);
+        }
+        // If no $id or $ref, traverse deeper
+        else {
+          result.push(...extractTypes(schema, parentId));
+        }
+      }
+    });
+  }
+
+  // Process allOf array
+  if (Array.isArray(record.allOf)) {
+    record.allOf.forEach((schema: any) => {
+      if (schema && typeof schema === 'object') {
+        if (schema.$ref && typeof schema.$ref === 'string') {
+          result.push(schema.$ref);
+        } else {
+          result.push(...extractTypes(schema, parentId));
+        }
+      }
+    });
+  }
+
+  return _.uniq(result);
 }
 
 export function buildDataFieldValue(
   type: string,
   schema: CredentialSchemaDto['schemas'],
-): CredentialRequests {
+): CredentialRequests | null {
   const selectedSchema = schema[type];
   const isComposedSchema = isComposed(selectedSchema);
 
   if (isComposedSchema) {
+    const children = extractTypes(selectedSchema, type)
+      .map((item) => buildDataFieldValue(item, schema))
+      .filter((child): child is CredentialRequests => child !== null);
+
     return {
       type,
       mandatory: MandatoryEnum.NO,
       description: '',
       allowUserInput: true,
       multi: false,
-      children: extractTypes(selectedSchema).map((item) =>
-        buildDataFieldValue(item, schema),
-      ),
+      ...(children.length > 0 ? { children } : {}),
     };
   }
 
@@ -59,7 +85,6 @@ export function buildDataFieldValue(
     mandatory: MandatoryEnum.NO,
     description: '',
     allowUserInput: true,
-    // We want to default to true if is email credential.
     multi: type === 'EmailCredential',
   };
 }

--- a/src/stories/components/CredentialRequestsEditor.stories.tsx
+++ b/src/stories/components/CredentialRequestsEditor.stories.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 import { Box } from '@mui/material';


### PR DESCRIPTION
## Summary
Fix issue with [buildDataFieldValue](cci:1://file:///Users/iagormoraes/Desktop/projects/UnumID/shared-ui-elements/src/components/CredentialRequestsEditor/utils/buildDataFieldValue.ts:80:0-112:1) where nested schema types were being incorrectly included in the parent list. Now child schemas like `CurrencyCredential` and `AmountCredential` will only appear under their direct parent `AnnualIncomeCredential`, not at the root level.

[Ticket](<!-- link to ticket -->)

## Changes
- aece138: Refactored [extractTypes](cci:1://file:///Users/iagormoraes/Desktop/projects/UnumID/shared-ui-elements/src/components/CredentialRequestsEditor/utils/buildDataFieldValue.ts:36:0-84:1) function to properly handle schema hierarchy:
  - Only collect direct children of each schema
  - Stop traversing when finding a schema with `$id`
  - Prevent nested types from appearing at parent levels
  - Maintain proper schema relationships (e.g., `CurrencyCredential` and `AmountCredential` only appear under `AnnualIncomeCredential`)

## Testing
- Locally tested with `EmployerCredential` schema
- Verified that nested credentials (e.g., `CurrencyCredential`, `AmountCredential`) only appear under their direct parent
- Confirmed that the schema hierarchy is maintained correctly
- Tested with various nested schema structures to ensure proper type collection

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects