### PR TITLE
feat: fix charts to make sure they render 1-click successes when ther…

### DIFF
--- a/src/components/chart/OneClickOverTimeChart/OneClickTimeSeriesDataMapper.ts
+++ b/src/components/chart/OneClickOverTimeChart/OneClickTimeSeriesDataMapper.ts
@@ -51,12 +51,10 @@ export function mapTimeSeriesData(
   const mappedData = brands.flatMap(({ _raw: brand }) => {
     const brandData = data?.find((item) => item.brandUuid === brand.brandUuid);
 
-    const chartData = (brandData?.interval ?? [])
-      .map((item) => ({
-        date: +new Date(item.date),
-        value: Number(item[keyValue] || 0),
-      }))
-      .filter((item) => item.value > 0);
+    const chartData = (brandData?.interval ?? []).map((item) => ({
+      date: +new Date(item.date),
+      value: Number(item[keyValue] || 0),
+    }));
 
     return {
       uuid: brand.brandUuid,

--- a/src/components/chart/SeriesPercentageChart/index.tsx
+++ b/src/components/chart/SeriesPercentageChart/index.tsx
@@ -120,16 +120,22 @@ const formatChartData = (
       // Calculate percentages for non-total fields
       nonTotalKeys.forEach((key) => {
         const absoluteValue = entry[`${key}_absolute`] as number;
-        const percentage =
-          totalValue > 0
-            ? new Decimal(absoluteValue.toString())
-                .div(totalValue)
-                .mul(100)
-                .toFixed(2, Decimal.ROUND_DOWN)
-            : '0.00';
+        let percentage;
 
-        // Store the percentage for the area chart
-        entry[key] = parseFloat(percentage);
+        if (totalValue === 0) {
+          percentage = '100.00';
+          entry[key] = 100;
+        } else {
+          percentage =
+            totalValue > 0
+              ? new Decimal(absoluteValue.toString())
+                  .div(totalValue)
+                  .mul(100)
+                  .toFixed(2, Decimal.ROUND_DOWN)
+              : '0.00';
+          // Store the percentage for the area chart
+          entry[key] = parseFloat(percentage);
+        }
       });
 
       return {
@@ -149,6 +155,7 @@ export function SeriesPercentageChart(
     return formatChartData(props.data, props.keyValues);
   }, [props.data, props.keyValues]);
 
+  console.log('test', formattedData);
   return (
     <Box sx={{ width: '100%', height: '100%', ...props.sx }}>
       <ResponsiveContainer width='100%' height='100%'>
@@ -205,7 +212,7 @@ export function SeriesPercentageChart(
               // Calculate percentage
               const percentage = !isTotal
                 ? total === 0
-                  ? '0.00'
+                  ? '100.00'
                   : new Decimal(absoluteValue.toString())
                       .div(total)
                       .mul(100)

--- a/src/stories/components/chart/SeriesChart.stories.tsx
+++ b/src/stories/components/chart/SeriesChart.stories.tsx
@@ -61,20 +61,23 @@ const mockData = [
     color: '#0000ff',
     integrationType: 'hosted',
     chartData: [
-      { date: 1734973560000, value: 1 },
-      { date: 1734969240000, value: 3 },
-      { date: 1734562140000, value: 2 },
-      { date: 1734562080000, value: 4 },
-      { date: 1734558840000, value: 1 },
-      { date: 1734558660000, value: 3 },
-      { date: 1734558540000, value: 2 },
-      { date: 1734558480000, value: 5 },
-      { date: 1734464340000, value: 2 },
-      { date: 1734462540000, value: 4 },
-      { date: 1734462480000, value: 2 },
-      { date: 1734367560000, value: 3 },
-      { date: 1734351960000, value: 1 },
-      { date: 1734351900000, value: 4 },
+      {
+        date: 1739971140000,
+        value: 1,
+      },
+      {
+        date: 1739970240000,
+        value: 1,
+      },
+
+      {
+        date: 1739968980000,
+        value: 1,
+      },
+      {
+        date: 1739968920000,
+        value: 0,
+      },
     ],
   },
   {

--- a/src/stories/components/chart/SeriesPercentageChart.stories.tsx
+++ b/src/stories/components/chart/SeriesPercentageChart.stories.tsx
@@ -43,7 +43,30 @@ const generateRandomData = (days = 30) => {
 const sampleData = [
   {
     uuid: 'b07cbc37-fe8f-4920-a6b9-c4e9dfe193cd',
-    chartData: generateRandomData(30),
+    chartData: [
+      ...generateRandomData(20),
+      {
+        date: 1739971140000,
+        oneClickSuccess: 1,
+        oneClickCreated: 1,
+      },
+      {
+        date: 1739970240000,
+        oneClickSuccess: 1,
+        oneClickCreated: 1,
+      },
+
+      {
+        date: 1739968980000,
+        oneClickSuccess: 1,
+        oneClickCreated: 0,
+      },
+      {
+        date: 1739968920000,
+        oneClickSuccess: 0,
+        oneClickCreated: 1,
+      },
+    ],
   },
 ];
 


### PR DESCRIPTION
fix charts to make sure they render 1-click successes when there are no created ones

## Summary
<!---
1-2 sentences summarizing the changes included in this PR
--->

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
<!---
List all non-trivial changes included in this PR. Bullet points are fine or the individual commits that make up this PR.
--->

## Testing
<!---
How did you test your changes? How might someone else test them?
--->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects