### PR TITLE
feat: add navigator online state and resize observer hook

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -14,3 +14,5 @@ export * from './useIntersectionObserver';
 export * from './useCounter';
 export * from './useOnClickOutside';
 export * from './usePrevious';
+export * from './useResizeObserver';
+export * from './useNavigatorOnline';

--- a/src/hooks/useNavigatorOnline.ts
+++ b/src/hooks/useNavigatorOnline.ts
@@ -1,0 +1,47 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * A React hook that tracks the browser's online/offline status.
+ * Uses the Navigator.onLine property and online/offline events for efficient status tracking.
+ * Implements useSyncExternalStore for React 18+ concurrent rendering compatibility.
+ *
+ * Features:
+ * - SSR compatible (defaults to online during server-side rendering)
+ * - Updates automatically when network status changes
+ * - Type-safe return value
+ * - Zero dependencies
+ *
+ * @returns {boolean} Current online status of the browser
+ */
+export function useNavigatorOnline(): boolean {
+  // Set up subscription to online/offline events
+  const subscribe = (callback: () => void): (() => void) => {
+    // Return no-op for server-side rendering
+    if (typeof window === 'undefined') return () => {};
+
+    // Add event listeners for online/offline events
+    window.addEventListener('online', callback);
+    window.addEventListener('offline', callback);
+
+    // Cleanup function to remove event listeners
+    return () => {
+      window.removeEventListener('online', callback);
+      window.removeEventListener('offline', callback);
+    };
+  };
+
+  // Get current online status
+  const getSnapshot = (): boolean => {
+    // Return true for server-side rendering
+    if (typeof navigator === 'undefined') return true;
+    return navigator.onLine;
+  };
+
+  // Server snapshot always returns online status
+  const getServerSnapshot = (): boolean => {
+    return true;
+  };
+
+  // Subscribe to online status changes using React 18's useSyncExternalStore
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/src/hooks/useResizeObserver.ts
+++ b/src/hooks/useResizeObserver.ts
@@ -1,0 +1,68 @@
+import { useSyncExternalStore, useRef } from 'react';
+
+/**
+ * A React hook that observes and returns the dimensions of a DOM element.
+ * Uses ResizeObserver API for efficient size tracking and useSyncExternalStore
+ * for React 18+ concurrent rendering compatibility.
+ * @param containerRef - React ref object pointing to the DOM element to observe
+ * @returns [width, height] - Array containing the current width and height. Returns 'auto' for each dimension if the ref is not yet attached.
+ */
+export function useResizeObserver(
+  containerRef: React.RefObject<HTMLDivElement>,
+): Array<string | number> {
+  // Cache for the last known dimensions
+  const dimensionsCache = useRef<[string | number, string | number]>([
+    'auto',
+    'auto',
+  ]);
+
+  // Set up the resize observer subscription
+  const subscribe = (callback: () => void): (() => void) => {
+    if (
+      typeof window === 'undefined' ||
+      typeof ResizeObserver === 'undefined'
+    ) {
+      return () => {};
+    }
+
+    if (!containerRef.current) return () => {};
+
+    // Create a new ResizeObserver instance that calls our callback
+    const resizeObserver = new ResizeObserver(callback);
+    resizeObserver.observe(containerRef.current);
+
+    // Cleanup function to disconnect the observer when the component unmounts
+    return () => {
+      resizeObserver.disconnect();
+    };
+  };
+
+  // Get the current dimensions of the observed element
+  const getSnapshot = (): Array<string | number> => {
+    if (typeof window === 'undefined') {
+      return dimensionsCache.current;
+    }
+
+    const rect = containerRef.current?.getBoundingClientRect();
+    const width = rect?.width ?? 'auto';
+    const height = rect?.height ?? 'auto';
+
+    // Only create a new array if the dimensions have changed
+    if (
+      dimensionsCache.current[0] !== width ||
+      dimensionsCache.current[1] !== height
+    ) {
+      dimensionsCache.current = [width, height];
+    }
+
+    return dimensionsCache.current;
+  };
+
+  // Server snapshot always returns the initial dimensions
+  const getServerSnapshot = (): Array<string | number> => {
+    return dimensionsCache.current;
+  };
+
+  // Subscribe to size changes using React 18's useSyncExternalStore
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/src/stories/hooks/useNavigatorOnline.stories.tsx
+++ b/src/stories/hooks/useNavigatorOnline.stories.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+
+import { useNavigatorOnline } from '../../hooks/useNavigatorOnline';
+
+const OnlineStatusDemo: React.FC = () => {
+  const isOnline = useNavigatorOnline();
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1rem',
+        alignItems: 'center',
+        padding: '2rem',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.5rem',
+        }}
+      >
+        <div
+          style={{
+            width: '12px',
+            height: '12px',
+            borderRadius: '50%',
+            backgroundColor: isOnline ? '#0dbc3d' : '#dc3545',
+          }}
+        />
+        <span style={{ fontSize: '1.2rem' }}>
+          {isOnline ? 'Online' : 'Offline'}
+        </span>
+      </div>
+
+      <div
+        style={{
+          marginTop: '1rem',
+          padding: '1rem',
+          backgroundColor: '#f8f9fa',
+          borderRadius: '8px',
+          fontSize: '0.9rem',
+          color: '#666',
+          maxWidth: '300px',
+          textAlign: 'center',
+        }}
+      >
+        Toggle your device&apos;s internet connection or use browser DevTools to
+        simulate offline mode
+      </div>
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Hooks/useNavigatorOnline',
+  component: OnlineStatusDemo,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          "A hook that tracks the browser's online/offline status. Try toggling your network connection to see it in action.",
+      },
+    },
+  },
+} satisfies Meta<typeof OnlineStatusDemo>;
+
+export default meta;
+
+const Template: StoryFn<typeof OnlineStatusDemo> = () => <OnlineStatusDemo />;
+
+export const Default = Template;

--- a/src/stories/hooks/useResizeObserver.stories.tsx
+++ b/src/stories/hooks/useResizeObserver.stories.tsx
@@ -1,0 +1,74 @@
+import React, { useRef } from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+import { motion } from 'framer-motion';
+
+import { useResizeObserver } from '../../hooks/useResizeObserver';
+
+const ResizeDemo: React.FC = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [width, height] = useResizeObserver(containerRef);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1rem',
+        alignItems: 'center',
+      }}
+    >
+      <div style={{ marginBottom: '1rem' }}>
+        <p>Current dimensions:</p>
+        <code>
+          width: {width}px, height: {height}px
+        </code>
+      </div>
+
+      <motion.div
+        ref={containerRef}
+        style={{
+          background: 'linear-gradient(45deg, #0dbc3d 30%, #008a01 90%)',
+          borderRadius: '8px',
+          padding: '20px',
+          cursor: 'pointer',
+          color: 'white',
+          textAlign: 'center',
+        }}
+        initial={{ width: 200, height: 100 }}
+        whileHover={{
+          width: 300,
+          height: 150,
+          transition: { type: 'spring', stiffness: 300, damping: 20 },
+        }}
+      >
+        Hover me to resize!
+      </motion.div>
+
+      <p
+        style={{
+          fontSize: '0.9rem',
+          color: '#666',
+          maxWidth: '300px',
+          textAlign: 'center',
+        }}
+      >
+        This demo uses Framer Motion for smooth animations. The dimensions above
+        update in real-time as you hover over the box.
+      </p>
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Hooks/useResizeObserver',
+  component: ResizeDemo,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof ResizeDemo>;
+
+export default meta;
+
+const Template: StoryFn<typeof ResizeDemo> = () => <ResizeDemo />;
+
+export const Default = Template;


### PR DESCRIPTION
## Summary
Added two new hooks: `useNavigatorOnline` for tracking browser's online status and `useResizeObserver` for observing element dimensions. Both hooks are SSR-compatible and use React 18's `useSyncExternalStore` for concurrent rendering support.

[Ticket](<!-- link to ticket -->)

## Changes
From commit [ede35be](<!-- link to commit -->):
- Added `useNavigatorOnline` hook with SSR support and comprehensive documentation
- Added `useResizeObserver` hook with SSR support and comprehensive documentation
- Created Storybook stories for both hooks with interactive demos
- Added hooks to the main exports in `index.ts`

## Testing
### Locally for Testing
1. Run Storybook and test `useNavigatorOnline`:
   - Toggle network connection to verify online/offline state changes
   - Use browser DevTools to simulate offline mode
   - Verify SSR compatibility by disabling JavaScript

2. Test `useResizeObserver`:
   - Hover over the demo element to see dimension changes
   - Resize browser window to verify observer updates
   - Verify SSR compatibility by disabling JavaScript

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects