### PR TITLE
Update wrap promise type

### DIFF
--- a/src/utils/wrapPromise.ts
+++ b/src/utils/wrapPromise.ts
@@ -1,19 +1,17 @@
-type WrappedPromiseEitherResponse<D, Error> =
-  | [Awaited<D>, null]
-  | [null, Error];
+type WrappedPromiseEitherResponse<D, E> = [Awaited<D>, null] | [null, E];
 
 /**
  * Wrap a promise to return an array with the data and the error.
  * @param promise The promise to wrap
  * @returns
  */
-export async function wrapPromise<D, Error = any>(
+export async function wrapPromise<D, E = object>(
   promise: PromiseLike<D>,
-): Promise<WrappedPromiseEitherResponse<D, Error>> {
+): Promise<WrappedPromiseEitherResponse<D, E>> {
   try {
     const data = await promise;
     return [data, null];
   } catch (error) {
-    return [null, error as Error];
+    return [null, error as E];
   }
 }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -32,6 +32,7 @@ export default defineConfig({
         'utils/masks': resolvePath('src/utils/masks/index.ts'),
         'utils/string': resolvePath('src/utils/string/index.ts'),
         'utils/phone': resolvePath('src/utils/phone.ts'),
+        'utils/wrapPromise': resolvePath('src/utils/wrapPromise.ts'),
       },
       formats: ['es'],
       fileName: (format, entryName) => {


### PR DESCRIPTION
## Summary
Fix type inference in [wrapPromise](cci:1://file:///Users/iagormoraes/Desktop/projects/UnumID/shared-ui-elements/src/utils/wrapPromise.ts:2:0-16:1) utility by updating the error type default to `object` and adding the utility to the exports.

[Ticket](<!-- link to ticket -->)

## Changes
- [eb4c5ec] Fix type inference in [wrapPromise](cci:1://file:///Users/iagormoraes/Desktop/projects/UnumID/shared-ui-elements/src/utils/wrapPromise.ts:2:0-16:1) by changing the default error type from `unknown` to `object`
- [5e53d39] Add [wrapPromise](cci:1://file:///Users/iagormoraes/Desktop/projects/UnumID/shared-ui-elements/src/utils/wrapPromise.ts:2:0-16:1) utility to the exports in [vite.config.mts](cci:7://file:///Users/iagormoraes/Desktop/projects/UnumID/shared-ui-elements/vite.config.mts:0:0-0:0)

## Testing
- Locally for Testing
- Test the utility with async functions that may throw errors and verify that TypeScript correctly infers the return type
- Test the utility in a component that imports it from the package to ensure it's properly exported

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects