### PR TITLE
fix: increase threshold and make an offset to prevent being overflown

### DIFF
--- a/src/components/chart/ErrorCodesChart/index.tsx
+++ b/src/components/chart/ErrorCodesChart/index.tsx
@@ -63,7 +63,7 @@ interface ErrorCodesChartProps {
  */
 export function ErrorCodesChart({
   data,
-  threshold = 100,
+  threshold = 120,
   isLoading,
   isFetching,
   isSuccess,
@@ -106,7 +106,7 @@ export function ErrorCodesChart({
       }}
       yAxis={{
         tickLine: false,
-        domain: [0, `dataMax + ${threshold}`],
+        domain: [0, `dataMax + ${threshold > 0 ? threshold + 5 : 0}`],
       }}
       tooltip={{
         labelFormatter: (value) => 'Total',

--- a/src/components/chart/ReasonCodesChart/index.tsx
+++ b/src/components/chart/ReasonCodesChart/index.tsx
@@ -106,7 +106,7 @@ export function ReasonCodesChart({
       }}
       yAxis={{
         tickLine: false,
-        domain: [0, `dataMax + ${threshold}`],
+        domain: [0, `dataMax + ${threshold > 0 ? threshold + 5 : 0}`],
       }}
       tooltip={{
         labelFormatter: (value) => 'Total',


### PR DESCRIPTION
## Summary
Prevent the reference lines from being drawn outside the canvas.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- fixed reason codes
- fixed error codes

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects