### PR TITLE
fix: prevent duplicated key to render

### DIFF
--- a/src/components/chart/MonthlySignupsOverviewTable/MonthlySignupsOverviewTable.tsx
+++ b/src/components/chart/MonthlySignupsOverviewTable/MonthlySignupsOverviewTable.tsx
@@ -13,6 +13,7 @@ import { LoadingChartSection } from '../LoadingChartSection';
 
 export type MonthlySignupsOverviewTableData = {
   month: string;
+  brandUuid: string;
   brand: string;
   integrationType: string;
   total: number;
@@ -51,7 +52,7 @@ export const MonthlySignupsOverviewTable: React.FC<
         </TableHead>
         <TableBody>
           {data.map((row) => (
-            <TableRow key={`${row.brand}-${row.month}`}>
+            <TableRow key={`${row.brandUuid}-${row.month}`}>
               <TableCell>
                 {new Date(row.month).toLocaleDateString(undefined, {
                   month: 'short',

--- a/src/components/chart/MonthlySignupsOverviewTable/MonthlySignupsOverviewTableDataMapper.ts
+++ b/src/components/chart/MonthlySignupsOverviewTable/MonthlySignupsOverviewTableDataMapper.ts
@@ -35,7 +35,7 @@ export const mapMonthlySignupsOverviewTableData = ({
     if (!brand || !brandData.interval) return [];
 
     return brandData.interval.map((interval) => ({
-      month: new Date(interval.date).toISOString(),
+      month: interval.date,
       brandUuid: brandData.brandUuid,
       brand: brand.brandName,
       integrationType: kebabCaseToPretty(brand.integrationType),

--- a/src/components/chart/MonthlySignupsOverviewTable/MonthlySignupsOverviewTableDataMapper.ts
+++ b/src/components/chart/MonthlySignupsOverviewTable/MonthlySignupsOverviewTableDataMapper.ts
@@ -36,6 +36,7 @@ export const mapMonthlySignupsOverviewTableData = ({
 
     return brandData.interval.map((interval) => ({
       month: new Date(interval.date).toISOString(),
+      brandUuid: brandData.brandUuid,
       brand: brand.brandName,
       integrationType: kebabCaseToPretty(brand.integrationType),
       total: interval.oneClickCreated,

--- a/src/stories/components/chart/MonthlySignupsOverviewTable.stories.tsx
+++ b/src/stories/components/chart/MonthlySignupsOverviewTable.stories.tsx
@@ -17,6 +17,7 @@ type Story = StoryObj<typeof MonthlySignupsOverviewTable>;
 const mockData = [
   {
     month: '2025-01-01T00:00:00.000Z',
+    brandUuid: '123',
     brand: 'Example Brand 1',
     integrationType: 'Hosted',
     total: 150,
@@ -25,6 +26,7 @@ const mockData = [
   },
   {
     month: '2025-01-01T00:00:00.000Z',
+    brandUuid: '1234',
     brand: 'Example Brand 2',
     integrationType: 'Semi Hosted',
     total: 200,
@@ -33,6 +35,7 @@ const mockData = [
   },
   {
     month: '2025-01-01T00:00:00.000Z',
+    brandUuid: '1235',
     brand: 'Example Brand 3',
     integrationType: 'Non Hosted',
     total: 180,
@@ -40,6 +43,7 @@ const mockData = [
   },
   {
     month: '2025-02-01T00:00:00.000Z',
+    brandUuid: '123',
     brand: 'Example Brand 1',
     integrationType: 'Hosted',
     total: 175,
@@ -48,6 +52,7 @@ const mockData = [
   },
   {
     month: '2025-02-01T00:00:00.000Z',
+    brandUuid: '1234',
     brand: 'Example Brand 2',
     integrationType: 'Semi Hosted',
     total: 225,
@@ -56,6 +61,7 @@ const mockData = [
   },
   {
     month: '2025-02-01T00:00:00.000Z',
+    brandUuid: '1235',
     brand: 'Example Brand 3',
     integrationType: 'Non Hosted',
     total: 195,


### PR DESCRIPTION
## Summary
Added brandUuid to MonthlySignupsOverviewTable data to prevent duplicate keys in table rows rendering, improving React's reconciliation process.

[Ticket](<!-- link to ticket -->)

## Changes
- [317a8af] Fixed duplicate key issue in MonthlySignupsOverviewTable:
  - Added `brandUuid` to table data interface and mapper
  - Updated table row key to use `brandUuid` instead of brand name
  - Updated stories mock data to include `brandUuid`

## Testing
- Locally for Testing
- Verify table renders correctly with the new unique keys
- Check that rows are properly identified and updated when data changes
- Ensure no console warnings about duplicate keys
- Confirm table functionality remains unchanged with the new key structure

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects