### PR TITLE
fix: prevent duplicated key warning

### DIFF
--- a/src/components/chart/SeriesChartLegend/index.tsx
+++ b/src/components/chart/SeriesChartLegend/index.tsx
@@ -153,7 +153,7 @@ export function SeriesChartLegend(props: SeriesChartLegendProps): ReactElement {
     >
       <AnimatePresence>
         {payload?.map((entry) => (
-          <Grid2 key={`item-${entry.value}`}>
+          <Grid2 key={`item-${(entry.payload as any).uuid}-${entry.value}`}>
             <EntryBlock
               entry={entry}
               payload={payload}


### PR DESCRIPTION
## Summary
Fixed React key warning in SeriesChartLegend by using a combination of UUID and value to ensure unique keys for each legend entry.

[Ticket](<!-- link to ticket -->)

## Changes
- [01e46e5] Fixed duplicate key warning in SeriesChartLegend:
  - Updated Grid2 component key to use both UUID and value from entry payload
  - Changed key format from `item-${entry.value}` to `item-${entry.payload.uuid}-${entry.value}`
  - Improved React's reconciliation process for legend items

## Testing
- Locally for Testing
- Verify legend renders correctly with the new unique keys
- Check React console for any key-related warnings
- Ensure legend animation and interaction behavior remains unchanged
- Test with multiple data series to confirm unique key generation

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects