### PR TITLE
feat(OTPInput): add error state

### DIFF
--- a/src/components/form/OTPInput.tsx
+++ b/src/components/form/OTPInput.tsx
@@ -27,6 +27,7 @@ import { v4 as uuid } from 'uuid';
 interface OTPInputProps {
   name?: string;
   onChange?: (event: { target: { value: string } }) => void;
+  error?: boolean;
   disabled?: boolean;
   sx?: SxProps;
   autoComplete?: string;
@@ -123,14 +124,20 @@ function OTPInputComponent(
           borderStyle: 'solid',
           borderColor: 'rgba(0, 0, 0, 0.23)',
           borderWidth: 1,
+          ...(props.error && {
+            borderColor: theme.palette.error.main,
+            boxShadow: `inset 0 0 0 1px ${theme.palette.error.main}`,
+          }),
         },
         ...(isFocused && {
           '& input': {
             borderRadius: 1,
             borderStyle: 'solid',
             borderWidth: 1,
-            borderColor: theme.palette.primary.main,
-            boxShadow: `inset 0 0 0 1px ${theme.palette.primary.main}`,
+            borderColor: props.error
+              ? theme.palette.error.main
+              : theme.palette.primary.main,
+            boxShadow: `inset 0 0 0 1px ${props.error ? theme.palette.error.main : theme.palette.primary.main}`,
           },
         }),
       },

--- a/src/stories/components/form/OTPInput.stories.tsx
+++ b/src/stories/components/form/OTPInput.stories.tsx
@@ -25,6 +25,7 @@ const meta = {
     name: 'otp',
     onChange: fn(),
     disabled: false,
+    error: false,
   },
   argTypes: {
     ref: {
@@ -39,6 +40,15 @@ type Story = StoryObj<typeof OTPInput>;
 
 // More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
 export const Default: Story = {};
+
+export const WithError: Story = {
+  args: {
+    name: 'otp',
+    onChange: fn(),
+    disabled: false,
+    error: true,
+  },
+};
 
 interface OTPWithControlsProps {
   name?: string;


### PR DESCRIPTION
## Summary
Add error prop to display an errored state.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- added error prop and colors
- added new story

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects