### PR TITLE
fix(DateInput): Added  new prop to vertical align picker preventing o…

### DIFF
--- a/src/components/form/DateInput/index.tsx
+++ b/src/components/form/DateInput/index.tsx
@@ -9,8 +9,8 @@ import {
 import { Box, Stack, TextField, type TextFieldProps } from '@mui/material';
 import { CalendarMonth } from '@mui/icons-material';
 import DatePicker from 'react-datepicker';
-import pickerCSS from '../../../styles/lib/react-datepicker.css?inline=true';
 
+import pickerCSS from '../../../styles/lib/react-datepicker.css?inline=true';
 import { masks } from '../../../utils/masks';
 import { useOnClickOutside } from '../../../hooks';
 import { InputMask } from '../InputMask';
@@ -21,6 +21,7 @@ interface DateInputProps extends Omit<TextFieldProps, 'onBlur' | 'onChange'> {
   helperText?: string;
   onChange?: (value: string) => void;
   onBlur?: ChangeEventHandler<HTMLInputElement>;
+  overflowPicker?: boolean;
 }
 
 const GhostInput = forwardRef(function RenderInput(
@@ -45,9 +46,11 @@ const GhostInput = forwardRef(function RenderInput(
 const Picker = function RenderPicker({
   value,
   onChange,
+  overflowPicker = false,
 }: {
   value: string;
   onChange: (event: { target: { value: string } }) => void;
+  overflowPicker?: boolean;
 }): ReactElement {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
@@ -96,7 +99,16 @@ const Picker = function RenderPicker({
   };
 
   return (
-    <Box ref={ref}>
+    <Box
+      ref={ref}
+      sx={{
+        '& .react-datepicker-popper': overflowPicker
+          ? {
+              transform: 'translate(-32px, calc(-50% + 16px))!important',
+            }
+          : {},
+      }}
+    >
       <style>{pickerCSS}</style>
       <DatePicker
         open={open}
@@ -117,6 +129,7 @@ const Picker = function RenderPicker({
           const formattedDate = formatDate(date);
           if (formattedDate) {
             onChange?.({ target: { value: formattedDate } });
+            setOpen(false);
           }
         }}
         customInput={<GhostInput />}
@@ -134,6 +147,7 @@ function DateInputComponent(
     onChange,
     onBlur,
     disabled,
+    overflowPicker = false,
     ...rest
   }: Readonly<DateInputProps>,
   ref: any,
@@ -168,7 +182,13 @@ function DateInputComponent(
     },
     fullWidth: true,
     InputProps: {
-      endAdornment: <Picker onChange={handleChange} value={value} />,
+      endAdornment: (
+        <Picker
+          onChange={handleChange}
+          value={value}
+          overflowPicker={overflowPicker}
+        />
+      ),
     },
     ...rest,
   };

--- a/src/stories/components/form/DateInput.stories.tsx
+++ b/src/stories/components/form/DateInput.stories.tsx
@@ -1,20 +1,28 @@
+import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
+import { Box, Stack } from '@mui/material';
+
 import { DateInput } from '../../../components/form/DateInput';
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta = {
   title: 'Components/form/DateInput',
   component: DateInput,
+  render: (args: any) => (
+    <Stack
+      justifyContent='center'
+      alignItems='center'
+      sx={{ width: 500, height: 400 }}
+    >
+      <Box>
+        <DateInput {...args} />
+      </Box>
+    </Stack>
+  ),
   parameters: {
     // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
     layout: 'centered',
-    docs: {
-      story: {
-        width: '12600px',
-        height: '400px',
-      },
-    },
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
@@ -37,6 +45,20 @@ export const Default: Story = {
     error: false,
     size: 'small',
     helperText: 'Helper text',
+  },
+  argTypes: {},
+};
+
+export const PickerOverflow: Story = {
+  args: {
+    name: 'date',
+    label: 'Label',
+    onChange: fn(),
+    disabled: false,
+    error: false,
+    size: 'small',
+    helperText: 'Helper text',
+    overflowPicker: true,
   },
   argTypes: {},
 };


### PR DESCRIPTION
## Summary
<!---
1-2 sentences summarizing the changes included in this PR
--->
Added a new prop to DateInput component to control vertical alignment of the picker, preventing overflow issues.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
<!---
List all non-trivial changes included in this PR. Bullet points are fine or the individual commits that make up this PR.
--->
- [3dfa875] Added new prop to vertical align picker preventing overflow in DateInput component

## Testing
<!---
How did you test your changes? How might someone else test them?
--->
- Locally for Testing

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects