### PR TITLE
Feat(DateInput): support default selected date picker

### DIFF
--- a/src/components/form/DateInput/index.tsx
+++ b/src/components/form/DateInput/index.tsx
@@ -159,7 +159,6 @@ const Picker = function RenderPicker({
         maxDate={maxDate}
         selected={selected}
         onSelect={(date) => {
-          console.log({ date });
           const formattedDate = formatDate(date);
           if (formattedDate) {
             onChange?.({ target: { value: formattedDate } });

--- a/src/components/form/DateInput/index.tsx
+++ b/src/components/form/DateInput/index.tsx
@@ -2,6 +2,7 @@ import {
   ForwardedRef,
   forwardRef,
   ReactElement,
+  useMemo,
   useRef,
   useState,
   type ChangeEventHandler,
@@ -21,6 +22,7 @@ interface DateInputProps extends Omit<TextFieldProps, 'onBlur' | 'onChange'> {
   helperText?: string;
   onChange?: (value: string) => void;
   onBlur?: ChangeEventHandler<HTMLInputElement>;
+  pickerDefaultSelectedDate?: Date;
   pickerClickOutsideBoundaryElement?: HTMLElement;
   pickerInputOverflow?: boolean;
 }
@@ -48,27 +50,22 @@ const GhostInput = forwardRef(function RenderInput(
 const Picker = function RenderPicker({
   value,
   onChange,
+  defaultSelectedDate,
   overflow = false,
   clickOutsideBoundaryElement,
 }: {
   value: string;
   onChange: (event: { target: { value: string } }) => void;
+  defaultSelectedDate?: Date;
   overflow?: boolean;
   clickOutsideBoundaryElement?: HTMLElement;
 }): ReactElement {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
 
-  // Close on outside click
-  useOnClickOutside(
-    ref,
-    () => {
-      setOpen(false);
-    },
-    'mousedown',
-    {},
-    clickOutsideBoundaryElement,
-  );
+  const defaultDate = new Date('08/01/1989');
+  const minDate = new Date(1900, 0, 1);
+  const maxDate = new Date();
 
   const formatDate = (date: Date | null): string => {
     if (!date) return '';
@@ -79,9 +76,9 @@ const Picker = function RenderPicker({
     }
 
     try {
-      const day = date.getDate().toString().padStart(2, '0');
-      const month = (date.getMonth() + 1).toString().padStart(2, '0');
-      const year = date.getFullYear();
+      const day = date.getUTCDate().toString().padStart(2, '0');
+      const month = (date.getUTCMonth() + 1).toString().padStart(2, '0');
+      const year = date.getUTCFullYear();
 
       // Validate ranges
       if (
@@ -100,6 +97,37 @@ const Picker = function RenderPicker({
       return '';
     }
   };
+
+  const selected = useMemo(() => {
+    if (!value) {
+      return defaultSelectedDate ?? undefined;
+    }
+    const valueDate = new Date(value);
+
+    if (isNaN(+valueDate)) {
+      return defaultDate;
+    }
+
+    if (
+      !/^\d{2}\/\d{2}\/\d{4}$/.test(value) ||
+      valueDate < minDate ||
+      valueDate > maxDate
+    ) {
+      return defaultDate;
+    }
+    return valueDate;
+  }, [value]);
+
+  // Close on outside click
+  useOnClickOutside(
+    ref,
+    () => {
+      setOpen(false);
+    },
+    'mousedown',
+    {},
+    clickOutsideBoundaryElement,
+  );
 
   return (
     <Box
@@ -127,10 +155,11 @@ const Picker = function RenderPicker({
         showMonthDropdown
         scrollableYearDropdown={false}
         dateFormat='MM/dd/yyyy'
-        minDate={new Date(1900, 0, 1)}
-        maxDate={new Date()}
-        selected={value ? new Date(value) : undefined}
-        onChange={(date) => {
+        minDate={minDate}
+        maxDate={maxDate}
+        selected={selected}
+        onSelect={(date) => {
+          console.log({ date });
           const formattedDate = formatDate(date);
           if (formattedDate) {
             onChange?.({ target: { value: formattedDate } });
@@ -152,6 +181,7 @@ function DateInputComponent(
     onChange,
     onBlur,
     disabled,
+    pickerDefaultSelectedDate,
     pickerClickOutsideBoundaryElement,
     pickerInputOverflow = false,
     ...rest
@@ -194,6 +224,7 @@ function DateInputComponent(
           value={value}
           overflow={pickerInputOverflow}
           clickOutsideBoundaryElement={pickerClickOutsideBoundaryElement}
+          defaultSelectedDate={pickerDefaultSelectedDate}
         />
       ),
     },

--- a/src/stories/components/form/DateInput.stories.tsx
+++ b/src/stories/components/form/DateInput.stories.tsx
@@ -62,3 +62,18 @@ export const PickerOverflow: Story = {
   },
   argTypes: {},
 };
+
+export const CustomDefaultSelectedDatePicker: Story = {
+  args: {
+    name: 'date',
+    label: 'Label',
+    onChange: fn(),
+    disabled: false,
+    error: false,
+    size: 'small',
+    helperText: 'Helper text',
+    pickerInputOverflow: true,
+    pickerDefaultSelectedDate: new Date('08/01/1989'),
+  },
+  argTypes: {},
+};


### PR DESCRIPTION
## Summary
<!---
1-2 sentences summarizing the changes included in this PR
--->
Added support for default selected date in DateInput component and improved date handling with UTC. Also includes fixes for date validation and selection behavior.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
<!---
List all non-trivial changes included in this PR. Bullet points are fine or the individual commits that make up this PR.
--->
- 031b155: Added default selected date picker support with the following changes:
  - Added `pickerDefaultSelectedDate` prop to DateInput component
  - Improved date handling using UTC methods
  - Enhanced date validation and selection logic
  - Added new story for CustomDefaultSelectedDatePicker
- 03426f8: Removed debug logging

## Testing
<!---
How did you test your changes? How might someone else test them?
--->
- Locally for Testing
- Test the new CustomDefaultSelectedDatePicker story in Storybook
- Verify date selection with default date (08/01/1989)
- Verify date validation for min (1900) and max (current) dates
- Test UTC date handling across different timezones

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects