### PR TITLE
feat: skip rendering of phone credential fields

### DIFF
--- a/src/components/form/OneClickForm/components/DataField/DataFieldAtomic.tsx
+++ b/src/components/form/OneClickForm/components/DataField/DataFieldAtomic.tsx
@@ -20,11 +20,7 @@ import {
   DataFieldSSNInput,
   DataFieldImageInput,
 } from './inputs';
-import {
-  DataFieldInputModeHeader,
-  DataFieldLegend,
-  DataFieldLeftSide,
-} from './';
+import { DataFieldInputModeHeader, DataFieldLeftSide } from './';
 
 /**
  * This component renders an atomic level credential, it displays the component by displayFormat.
@@ -39,6 +35,7 @@ export function DataFieldAtomic(): ReactElement | null {
     credentialDisplayInfo.credentialRequest?.allowUserInput;
   const canEdit = allowUserInput;
   const isEditMode = credentialDisplayInfo.uiState.isEditMode;
+  const fieldType = objectController.field.value.type;
 
   // HACK alert:
   // This calculation subtracts left side component and right side component to fit in.
@@ -92,6 +89,12 @@ export function DataFieldAtomic(): ReactElement | null {
     if (!isEditMode) {
       return null;
     }
+  }
+
+  // Phone credential should not be rendered as user already has provided the information.
+  // TODO - Provide this from features in one click form context options, this does not belong to the domain logic.
+  if (fieldType === credentialTypes.PhoneCredential) {
+    return null;
   }
 
   return (

--- a/src/components/form/OneClickForm/constants/credentialTypes.ts
+++ b/src/components/form/OneClickForm/constants/credentialTypes.ts
@@ -5,4 +5,5 @@ export const credentialTypes = {
   FullNameCredential: 'FullNameCredential',
   AddressCredential: 'AddressCredential',
   Line2Credential: 'Line2Credential',
+  PhoneCredential: 'PhoneCredential',
 } as const;


### PR DESCRIPTION
## Summary
This PR prevents phone credential fields from being rendered in the OneClickForm component when the field type is a PhoneCredential, as this information is already provided by the user.

[Ticket](<!-- link to ticket -->)

## Changes
- Added PhoneCredential type to credential type constants [e3f4835]
- Skip rendering DataFieldAtomic component when field type is PhoneCredential [e3f4835]
- Removed unused DataFieldLegend import [e3f4835]
- Added TODO to move this logic to OneClickForm context options in the future [e3f4835]

## Testing
- Locally for Testing
- Verify that phone credential fields are not displayed in the form
- Confirm that other credential fields continue to render correctly

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects