### PR TITLE
feat: implement checklist for multi brands select

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -5,7 +5,12 @@ import {
   MINIMAL_VIEWPORTS,
 } from '@storybook/addon-viewport';
 import { CssBaseline, ThemeProvider } from '@mui/material';
+import {
+  CustomAlertComponent,
+  SnackbarProvider,
+} from '../src/components/Snackbar';
 import { theme } from '../src/styles/theme';
+import React from 'react';
 
 import '@fontsource/lato/300.css';
 import '@fontsource/lato/400.css';
@@ -41,6 +46,18 @@ export const decorators = [
     Provider: ThemeProvider,
     GlobalStyles: CssBaseline,
   }),
+  // Add SnackbarProvider to enable snackbar notifications in storybook
+  (Story) => (
+    <SnackbarProvider
+      maxSnack={3}
+      autoHideDuration={5000}
+      Components={{
+        customAlertComponent: CustomAlertComponent,
+      }}
+    >
+      <Story />
+    </SnackbarProvider>
+  ),
 ];
 
 export default preview;

--- a/src/components/BrandFilterInput/BrandFilterInput.hook.ts
+++ b/src/components/BrandFilterInput/BrandFilterInput.hook.ts
@@ -37,7 +37,8 @@ export function useBrandFilterInput({
   const brandOptions = useMemo(
     () =>
       _.sortBy(toOption(groupedBrands), [
-        (option) => (option._raw as any).live,
+        // Sort by isLiveBrand property (if it exists) or fallback to live property
+        (option) => !option._raw.isLiveBrand,
       ]),
     [groupedBrands],
   );

--- a/src/components/BrandFilterInput/index.tsx
+++ b/src/components/BrandFilterInput/index.tsx
@@ -1,5 +1,27 @@
-import { Autocomplete, TextField } from '@mui/material';
+/**
+ * BrandFilterInput Component
+ *
+ * A customizable dropdown component for selecting brands with various features:
+ * - Single or multiple selection modes
+ * - "Select All" option for quickly selecting all brands
+ * - Maximum selection limit with error messaging
+ * - Brand grouping and sorting
+ *
+ * This component uses a controlled open/close state to fix a Material-UI Autocomplete bug
+ * where the dropdown would close unexpectedly when the mouse happened to be hovering
+ * over one of the selected items when opening the dropdown. By manually controlling
+ * the open state, we ensure the dropdown only closes when clicking outside the component.
+ */
+
+import {
+  Autocomplete,
+  TextField,
+  Checkbox,
+  Box,
+  Typography,
+} from '@mui/material';
 import { useSnackbar } from '../Snackbar';
+import { useMemo, useState } from 'react';
 import { BrandFilter, BrandGroupConfig } from './types';
 import { useBrandFilterInput } from './BrandFilterInput.hook';
 
@@ -58,61 +80,175 @@ export function BrandFilterInput({
     autocompleteKey = 'single';
   }
 
-  return (
-    <Autocomplete
-      key={autocompleteKey}
-      multiple={multiple}
-      value={multiple ? (value as Value[]) || [] : (value as Value)}
-      limitTags={3}
-      options={brandOptions}
-      getOptionKey={(option: Value) => option.value}
-      getOptionLabel={(option: Value) => option.name}
-      isOptionEqualToValue={(option: Value, value: Value | undefined) => {
-        if (!value) return false;
-        return option.value === value.value;
-      }}
-      onChange={(_, newValue) => {
-        if (
-          maximumSelectedBrands &&
-          Array.isArray(newValue) &&
-          newValue.length > maximumSelectedBrands
-        ) {
-          enqueueSnackbar(
-            `You can't select more than ${maximumSelectedBrands} brands.`,
-            'error',
-          );
-          return;
-        }
+  // Create a Select All option for multi-select mode
+  const selectAllOption: Value = useMemo(
+    () => ({
+      name: 'Select All',
+      value: 'select-all',
+      _raw: {} as any, // This is a virtual option, not a real brand
+    }),
+    [],
+  );
 
-        handleChange(newValue as BrandFilter | BrandFilter[] | null);
-      }}
-      clearOnBlur
-      disableClearable={!multiple}
-      disabled={isLoading}
-      {...(groupConfig && {
-        // Define how options should be grouped
-        groupBy: (option: Value) => {
-          // Extract the raw value using the specified key
-          const value = option._raw[groupConfig.key];
-          // Transform the value using the provided transform function or fallback to string conversion
-          return groupConfig.transform
-            ? groupConfig.transform(value)
-            : String(value);
-        },
-        // Use the provided sort function to determine group order
-        // If not provided, MUI will use alphabetical ordering
-        groupOrder: groupConfig.sortGroups,
-      })}
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          label={label}
-          placeholder='Select...'
-          inputProps={{ ...params.inputProps, flex: 1, width: '100%' }}
-          sx={{ width: '100%' }}
-        />
-      )}
-    />
+  // Add Select All option at the beginning of options array when in multiple mode
+  const optionsWithSelectAll = useMemo(() => {
+    return multiple ? [selectAllOption, ...brandOptions] : brandOptions;
+  }, [multiple, selectAllOption, brandOptions]);
+
+  // Determine if all available brands are currently selected
+  // Used to show the Select All option as checked when all brands are selected individually
+  const areAllBrandsSelected = useMemo(() => {
+    if (!multiple || !Array.isArray(value) || brandOptions.length === 0)
+      return false;
+    return (
+      value.length === brandOptions.length &&
+      brandOptions.every((brand) => value.some((v) => v.value === brand.value))
+    );
+  }, [multiple, value, brandOptions]);
+
+  // Handle select all functionality
+  const handleSelectAll = (newValue: Value | Value[] | null) => {
+    if (!multiple || !Array.isArray(newValue)) return newValue;
+
+    // Check if Select All is being selected or deselected
+    const isSelectAllSelected = newValue.some(
+      (item) => item.value === 'select-all',
+    );
+
+    // If all brands are already selected and user clicks on Select All again, unselect all brands
+    // This provides a quick way to clear all selections with a single click
+    if (isSelectAllSelected && areAllBrandsSelected) {
+      return [];
+    }
+    if (isSelectAllSelected) {
+      // If Select All is selected, select all brand options (excluding Select All)
+      // If maximumSelectedBrands is set and there are more brands than allowed, show error
+      if (
+        maximumSelectedBrands &&
+        brandOptions.length > maximumSelectedBrands
+      ) {
+        enqueueSnackbar(
+          `You can't select more than ${maximumSelectedBrands} brands.`,
+          'error',
+        );
+        // Don't select any brands when limit would be surpassed
+        // Return the current selection without the Select All option
+        return Array.isArray(value)
+          ? value.filter((item) => item.value !== 'select-all')
+          : [];
+      }
+      // Otherwise, select all brands
+      return brandOptions;
+    } else {
+      // If Select All is not in the selection, filter it out from the result
+      return newValue.filter((item) => item.value !== 'select-all');
+    }
+  };
+
+  // Track if the dropdown is open
+  const [isOpen, setIsOpen] = useState(false);
+
+  // Open the dropdown when clicking on the component
+  // This is part of the workaround for the Material-UI Autocomplete bug
+  // where the dropdown would close when hovering over options
+  const openDropdown = () => {
+    if (!isOpen) {
+      setIsOpen(true);
+    }
+  };
+
+  return (
+    <Box
+      onClick={openDropdown}
+      sx={{ position: 'relative', cursor: 'pointer' }}
+    >
+      <Autocomplete
+        key={autocompleteKey}
+        multiple={multiple}
+        value={multiple ? (value as Value[]) || [] : (value as Value)}
+        limitTags={3}
+        options={optionsWithSelectAll}
+        getOptionKey={(option: Value) => option.value}
+        getOptionLabel={(option: Value) => option.name}
+        isOptionEqualToValue={(option: Value, value: Value | undefined) => {
+          if (!value) return false;
+          return option.value === value.value;
+        }}
+        // Control the open state manually to prevent unwanted closing
+        open={isOpen}
+        // Empty onOpen handler prevents Autocomplete from managing its own open state
+        // onClose handler only triggers when clicking outside the component
+        onOpen={() => {}}
+        onClose={() => setIsOpen(false)}
+        onChange={(_, newValue) => {
+          // Process Select All option if needed
+          const processedValue = handleSelectAll(newValue);
+          // Check if we're trying to select more than the maximum allowed
+          if (
+            maximumSelectedBrands &&
+            Array.isArray(processedValue) &&
+            processedValue.length > maximumSelectedBrands
+          ) {
+            // If we're adding a new item (length increased), show error message
+            if (Array.isArray(value) && processedValue.length > value.length) {
+              enqueueSnackbar(
+                `You can't select more than ${maximumSelectedBrands} brands.`,
+                'error',
+              );
+              return;
+            }
+            // If we're replacing items (same length or decreased), allow the change
+          }
+          handleChange(processedValue);
+        }}
+        clearOnBlur
+        disableClearable={!multiple}
+        disabled={isLoading}
+        disableCloseOnSelect={multiple}
+        {...(groupConfig && {
+          // Define how options should be grouped
+          groupBy: (option: Value) => {
+            // Don't group the Select All option
+            if (option.value === 'select-all') return '';
+            // Extract the raw value using the specified key
+            const value = option._raw[groupConfig.key];
+            // Transform the value using the provided transform function or fallback to string conversion
+            return groupConfig.transform
+              ? groupConfig.transform(value)
+              : String(value);
+          },
+          // Use the provided sort function to determine group order
+          // If not provided, MUI will use alphabetical ordering
+          groupOrder: groupConfig.sortGroups,
+        })}
+        renderOption={(props, option, { selected }) => {
+          // For the Select All option, show it as selected if all brands are selected
+          // This creates a consistent UX where Select All appears checked when all items are selected
+          const isSelected =
+            option.value === 'select-all' ? areAllBrandsSelected : selected;
+
+          return (
+            <li {...props}>
+              <Box display='flex' alignItems='center' width='100%'>
+                {multiple && (
+                  <Checkbox checked={isSelected} sx={{ marginRight: 1 }} />
+                )}
+                <Typography>{option.name}</Typography>
+              </Box>
+            </li>
+          );
+        }}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label={label}
+            placeholder='Select...'
+            inputProps={{ ...params.inputProps, flex: 1, width: '100%' }}
+            sx={{ width: '100%' }}
+          />
+        )}
+      />
+    </Box>
   );
 }
 

--- a/src/stories/components/form/BrandFilterInput.stories.tsx
+++ b/src/stories/components/form/BrandFilterInput.stories.tsx
@@ -48,6 +48,157 @@ const mockBrands: Brands[] = [
     isLiveBrand: true,
     isApproved: true,
   },
+  {
+    brandUuid: '5',
+    brandName: 'Another Live Brand',
+    customerUuid: 'c5',
+    integrationType: 'SDK',
+    isLiveBrand: true,
+    isApproved: true,
+  },
+  {
+    brandUuid: '6',
+    brandName: 'Another Live Brand',
+    customerUuid: 'c6',
+    integrationType: 'SDK',
+    isLiveBrand: true,
+    isApproved: true,
+  },
+  {
+    brandUuid: '7',
+    brandName: 'Another Live Brand',
+    customerUuid: 'c7',
+    integrationType: 'SDK',
+    isLiveBrand: true,
+    isApproved: true,
+  },
+];
+
+// Extended mock data with many brands in different groups
+const extendedMockBrands: Brands[] = [
+  // API Integration - Live Brands
+  {
+    brandUuid: '101',
+    brandName: 'API Live Brand 1',
+    customerUuid: 'c101',
+    integrationType: 'API',
+    isLiveBrand: true,
+    isApproved: true,
+  },
+  {
+    brandUuid: '102',
+    brandName: 'API Live Brand 2',
+    customerUuid: 'c102',
+    integrationType: 'API',
+    isLiveBrand: true,
+    isApproved: true,
+  },
+  {
+    brandUuid: '103',
+    brandName: 'API Live Brand 3',
+    customerUuid: 'c103',
+    integrationType: 'API',
+    isLiveBrand: true,
+    isApproved: true,
+  },
+
+  // API Integration - Not Live Brands
+  {
+    brandUuid: '104',
+    brandName: 'API Not Live Brand 1',
+    customerUuid: 'c104',
+    integrationType: 'API',
+    isLiveBrand: false,
+    isApproved: true,
+  },
+  {
+    brandUuid: '105',
+    brandName: 'API Not Live Brand 2',
+    customerUuid: 'c105',
+    integrationType: 'API',
+    isLiveBrand: false,
+    isApproved: false,
+  },
+
+  // SDK Integration - Live Brands
+  {
+    brandUuid: '201',
+    brandName: 'SDK Live Brand 1',
+    customerUuid: 'c201',
+    integrationType: 'SDK',
+    isLiveBrand: true,
+    isApproved: true,
+  },
+  {
+    brandUuid: '202',
+    brandName: 'SDK Live Brand 2',
+    customerUuid: 'c202',
+    integrationType: 'SDK',
+    isLiveBrand: true,
+    isApproved: true,
+  },
+  {
+    brandUuid: '203',
+    brandName: 'SDK Live Brand 3',
+    customerUuid: 'c203',
+    integrationType: 'SDK',
+    isLiveBrand: true,
+    isApproved: false,
+  },
+
+  // SDK Integration - Not Live Brands
+  {
+    brandUuid: '204',
+    brandName: 'SDK Not Live Brand 1',
+    customerUuid: 'c204',
+    integrationType: 'SDK',
+    isLiveBrand: false,
+    isApproved: true,
+  },
+  {
+    brandUuid: '205',
+    brandName: 'SDK Not Live Brand 2',
+    customerUuid: 'c205',
+    integrationType: 'SDK',
+    isLiveBrand: false,
+    isApproved: false,
+  },
+
+  // Web Integration - Live Brands
+  {
+    brandUuid: '301',
+    brandName: 'Web Live Brand 1',
+    customerUuid: 'c301',
+    integrationType: 'Web',
+    isLiveBrand: true,
+    isApproved: true,
+  },
+  {
+    brandUuid: '302',
+    brandName: 'Web Live Brand 2',
+    customerUuid: 'c302',
+    integrationType: 'Web',
+    isLiveBrand: true,
+    isApproved: false,
+  },
+
+  // Web Integration - Not Live Brands
+  {
+    brandUuid: '303',
+    brandName: 'Web Not Live Brand 1',
+    customerUuid: 'c303',
+    integrationType: 'Web',
+    isLiveBrand: false,
+    isApproved: true,
+  },
+  {
+    brandUuid: '304',
+    brandName: 'Web Not Live Brand 2',
+    customerUuid: 'c304',
+    integrationType: 'Web',
+    isLiveBrand: false,
+    isApproved: false,
+  },
 ];
 
 const Template: StoryFn<typeof BrandFilterInput> = (args) => {
@@ -84,7 +235,6 @@ MultiSelect.args = {
   multiple: true,
   brands: mockBrands,
   isLoading: false,
-  maximumSelectedBrands: 3,
   defaultBrandUuids: ['1', '2'],
   groupConfig: null,
 };
@@ -144,5 +294,51 @@ MultiSelectGroupedByLiveStatus.args = {
     key: 'isLiveBrand',
     transform: (value: boolean) => (value ? 'Live Brands' : 'Not Live Yet'),
     sortGroups: (a, b) => (a === 'Live Brands' ? -1 : 1),
+  },
+};
+
+// Multi select with many brands grouped by integration type (no max limit)
+export const MultiSelectManyBrandsGroupedByIntegrationType = Template.bind({});
+MultiSelectManyBrandsGroupedByIntegrationType.args = {
+  value: [],
+  label: 'Select Multiple Brands (Grouped by Integration Type)',
+  multiple: true,
+  brands: extendedMockBrands,
+  isLoading: false,
+  groupConfig: {
+    key: 'integrationType',
+    transform: (value: string) => `${value} Integration`,
+    sortGroups: (a, b) => a.localeCompare(b),
+  },
+};
+
+// Multi select with many brands grouped by live status (no max limit)
+export const MultiSelectManyBrandsGroupedByLiveStatus = Template.bind({});
+MultiSelectManyBrandsGroupedByLiveStatus.args = {
+  value: [],
+  label: 'Select Multiple Brands (Grouped by Live Status)',
+  multiple: true,
+  brands: extendedMockBrands,
+  isLoading: false,
+  groupConfig: {
+    key: 'isLiveBrand',
+    transform: (value: boolean) => (value ? 'Live Brands' : 'Not Live Yet'),
+    sortGroups: (a, b) => (a === 'Live Brands' ? -1 : 1),
+  },
+};
+
+// Multi select with many brands grouped by approval status (no max limit)
+export const MultiSelectManyBrandsGroupedByApprovalStatus = Template.bind({});
+MultiSelectManyBrandsGroupedByApprovalStatus.args = {
+  value: [],
+  label: 'Select Multiple Brands (Grouped by Approval Status)',
+  multiple: true,
+  brands: extendedMockBrands,
+  isLoading: false,
+  groupConfig: {
+    key: 'isApproved',
+    transform: (value: boolean) =>
+      value ? 'Approved Brands' : 'Pending Approval',
+    sortGroups: (a, b) => (a === 'Approved Brands' ? -1 : 1),
   },
 };


### PR DESCRIPTION
## Summary
<!---
1-2 sentences summarizing the changes included in this PR
--->
Enhanced the BrandFilterInput component to improve dropdown behavior and implement intelligent "Select All" functionality that automatically checks/unchecks based on selection state.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
<!---
List all non-trivial changes included in this PR. Bullet points are fine or the individual commits that make up this PR.
--->
Fixed dropdown behavior to open when clicked and only close when clicking outside the component

Implemented automatic "Select All" checkbox state that shows as checked when all brands are selected individually

Added functionality to unselect all brands when clicking "Select All" while all brands are selected

Added comprehensive documentation explaining component behavior and the Material-UI Autocomplete bug workaround


## Testing
<!---
How did you test your changes? How might someone else test them?
--->
local, with storybooks
## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects