### PR TITLE
fix(color): contrast color and hex with hastag

### DIFF
--- a/src/utils/color/index.ts
+++ b/src/utils/color/index.ts
@@ -7,7 +7,7 @@ import tinycolor from 'tinycolor2';
  * @returns The lightened color.
  */
 export const lighten = (color: string, amount: number) => {
-  return tinycolor(color).lighten(amount).toHex();
+  return tinycolor(color).lighten(amount).toHexString();
 };
 
 /**
@@ -17,7 +17,7 @@ export const lighten = (color: string, amount: number) => {
  * @returns The darkened color.
  */
 export const darken = (color: string, amount: number) => {
-  return tinycolor(color).darken(amount).toHex();
+  return tinycolor(color).darken(amount).toHexString();
 };
 
 /**
@@ -26,7 +26,7 @@ export const darken = (color: string, amount: number) => {
  * @returns The best color to use for text on the given color.
  */
 export const contrastColor = (color: string, alpha: number = 1) => {
-  return tinycolor(tinycolor(color).isLight() ? '#000000' : '#fff000')
+  return tinycolor(tinycolor(color).isLight() ? '#000000' : '#ffffff')
     .setAlpha(alpha)
-    .toHex();
+    .toHexString();
 };

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -30,7 +30,7 @@ export default defineConfig({
         styles: resolvePath('src/styles/index.ts'),
         validations: resolvePath('src/validations/index.ts'),
         utils: resolvePath('src/utils/index.ts'),
-        'utils/color': resolvePath('src/utils/color.ts'),
+        'utils/color': resolvePath('src/utils/color/index.ts'),
         'utils/masks': resolvePath('src/utils/masks/index.ts'),
         'utils/string': resolvePath('src/utils/string/index.ts'),
         'utils/phone': resolvePath('src/utils/phone.ts'),


### PR DESCRIPTION
## Summary
This PR fixes color contrast issues and ensures proper hex color formatting with hashtags to improve accessibility and maintain consistent color syntax.

[Ticket](https://trello.com/link/to/ticket)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- [c76167e] Fixed color contrast ratios to improve accessibility and ensure proper hex color formatting with hashtags

## Testing
- Tested the color changes for appropriate contrast across all themes
- Confirmed that all hex color values now include hashtags for consistent formatting
- Locally for Testing

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects