### PR TITLE
fix: don't show "select live brands" under any grouping

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -31,7 +31,7 @@ const preview: Preview = {
         ...INITIAL_VIEWPORTS,
         ...MINIMAL_VIEWPORTS,
       },
-      defaultViewport: 'iphone14promax',
+      defaultViewport: 'desktop',
     },
   },
 };

--- a/src/components/BrandFilterInput/index.tsx
+++ b/src/components/BrandFilterInput/index.tsx
@@ -335,8 +335,13 @@ export function BrandFilterInput({
         {...(groupLiveBrand && {
           // Define how options should be grouped
           groupBy: (option: Value) => {
-            // Don't group the Select All option
-            if (option.value === 'select-all') return '';
+            // Don't group virtual options
+            if (
+              option.value === 'select-all' ||
+              option.value === 'select-live-brands'
+            ) {
+              return '';
+            }
             // Group by live status
             return option._raw.isLiveBrand ? 'Live Brands' : 'Not Live Yet';
           },


### PR DESCRIPTION
## Summary
<!---
1-2 sentences summarizing the changes included in this PR
--->
 don't show "select live brands" under any grouping and change default storybook viewport to desktop

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
<!---
List all non-trivial changes included in this PR. Bullet points are fine or the individual commits that make up this PR.
--->

## Testing
<!---
How did you test your changes? How might someone else test them?
--->
storybook

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects