### PR TITLE
Fix form fields behavior and update Places API integration

### DIFF
--- a/src/components/form/OneClickForm/components/CredentialsDisplay/CredentialsDisplay.tsx
+++ b/src/components/form/OneClickForm/components/CredentialsDisplay/CredentialsDisplay.tsx
@@ -60,6 +60,9 @@ export default function CredentialsDisplay(): ReactElement {
     <Box
       display='flex'
       sx={{
+        alignSelf: 'flex-start',
+        alignItems: 'flex-start',
+        justifyContent: 'flex-start',
         width: '100%',
         // Traverse the card image elements to apply flex to them.
         '& > div, & > div > div': {

--- a/src/components/form/OneClickForm/components/CredentialsDisplay/CredentialsDisplayContext.tsx
+++ b/src/components/form/OneClickForm/components/CredentialsDisplay/CredentialsDisplayContext.tsx
@@ -4,6 +4,7 @@ import {
   ReactNode,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useReducer,
   useState,
@@ -26,6 +27,7 @@ import {
   transformToFormObject,
   transformToFormSchema,
   extractChildrenFromCredentialFieldSet,
+  hasMandatoryCredentialRequests,
 } from './utils';
 
 export type CredentialsDisplayContext = {
@@ -408,6 +410,11 @@ export default function CredentialsDisplayProvider({
 
     process();
   };
+
+  // Set initial edit mode based on the presence of mandatory credential requests.
+  useLayoutEffect(() => {
+    setEditMode(hasMandatoryCredentialRequests(defaultValues));
+  }, [defaultValues]);
 
   return (
     <FormProvider {...form}>

--- a/src/components/form/OneClickForm/components/CredentialsDisplay/CredentialsDisplayContext.tsx
+++ b/src/components/form/OneClickForm/components/CredentialsDisplay/CredentialsDisplayContext.tsx
@@ -272,6 +272,9 @@ export default function CredentialsDisplayProvider({
     value: unknown,
     options?: { shouldValidate?: boolean },
   ): void => {
+    // Select the credential if it has a value.
+    handleSelectCredential(path, !!value, false);
+
     const field = produce(form.getValues(path), (draft: CredentialFieldSet) => {
       draft.value = value as any;
     });

--- a/src/components/form/OneClickForm/components/CredentialsDisplay/CredentialsDisplayContext.tsx
+++ b/src/components/form/OneClickForm/components/CredentialsDisplay/CredentialsDisplayContext.tsx
@@ -154,7 +154,7 @@ export default function CredentialsDisplayProvider({
   });
 
   useEffect(() => {
-    const subscription = form.watch((value) => {
+    const subscription = form.watch((value, field) => {
       // Refresh form schema is needed to be able to compare the updated values of sibling fields and their schemas.
       setFormSchema(() => {
         return transformToFormSchema(
@@ -165,7 +165,11 @@ export default function CredentialsDisplayProvider({
           oneClickFormOptions.options,
         );
       });
+
+      // Because the form schema is updating it state, we have to trigger the field validation.
+      void form.trigger(field.name);
     });
+
     return () => {
       subscription.unsubscribe();
     };

--- a/src/components/form/OneClickForm/components/CredentialsDisplay/utils/extractChildrenFromCredentialFieldSet.ts
+++ b/src/components/form/OneClickForm/components/CredentialsDisplay/utils/extractChildrenFromCredentialFieldSet.ts
@@ -1,9 +1,9 @@
 import { CredentialFieldSet } from '../types';
 
 /**
- * Extracts all nested child credential fields from a CredentialFieldSet object.
+ * Extracts all nested children credential field sets from a CredentialFieldSet object.
  *
- * @param {CredentialFieldSet} credentialFieldSet - The credential field set to extract child fields from.
+ * @param {CredentialFieldSet} credentialFieldSet - The credential field set to extract children from.
  * @returns {Record<string, CredentialFieldSet>} An object containing only the nested credential field sets,
  *          where keys are the property names and values are the corresponding CredentialFieldSet objects.
  */
@@ -11,9 +11,9 @@ export function extractChildrenFromCredentialFieldSet(
   credentialFieldSet: CredentialFieldSet,
 ): Record<string, CredentialFieldSet> {
   // Destructure the input object to separate base properties from nested child fields
-  const { id, value, type, credentialDisplayInfo, ...childs } =
+  const { id, value, type, credentialDisplayInfo, ...children } =
     credentialFieldSet;
 
   // Return only the nested child credential field sets
-  return childs;
+  return children;
 }

--- a/src/components/form/OneClickForm/components/CredentialsDisplay/utils/hasMandatoryCredentialRequests.ts
+++ b/src/components/form/OneClickForm/components/CredentialsDisplay/utils/hasMandatoryCredentialRequests.ts
@@ -1,0 +1,21 @@
+import { CredentialFieldSet } from '../types';
+
+import {
+  extractChildrenFromCredentialFieldSet,
+  isRequiredCredentialDisplayInfo,
+} from '../utils';
+
+export function hasMandatoryCredentialRequests(
+  fieldSet: CredentialFieldSet,
+): boolean {
+  const children = extractChildrenFromCredentialFieldSet(fieldSet);
+  const childEntries = Object.entries(children);
+  if (!childEntries.length) {
+    return isRequiredCredentialDisplayInfo(
+      fieldSet.credentialDisplayInfo.credentialRequest,
+    );
+  }
+  return childEntries.some(([_, childFieldSet]) =>
+    hasMandatoryCredentialRequests(childFieldSet),
+  );
+}

--- a/src/components/form/OneClickForm/components/CredentialsDisplay/utils/index.ts
+++ b/src/components/form/OneClickForm/components/CredentialsDisplay/utils/index.ts
@@ -15,3 +15,4 @@ export * from './transformToFormSchema';
 export * from './getParentPath';
 export * from './getLastPathName';
 export * from './extractChildrenFromCredentialFieldSet';
+export * from './hasMandatoryCredentialRequests';

--- a/src/components/form/OneClickForm/components/DataField/inputs/DataFieldDateInput.tsx
+++ b/src/components/form/OneClickForm/components/DataField/inputs/DataFieldDateInput.tsx
@@ -33,7 +33,7 @@ const DataFieldDateInputMemoized = memo(
       credentialDisplayInfo,
       handleChangeValueCredential,
     } = credentialsDisplayItem;
-    const { isValid, errorMessage } = itemValid;
+    const { isValid } = itemValid;
 
     // Arbitrary value to format the timestamp into human-readable date.
     const [localValue, setLocalValue] = useState<string>(
@@ -81,19 +81,25 @@ const DataFieldDateInputMemoized = memo(
           helperText={credentialDisplayInfo.credentialRequest?.description}
           onChange={(value) => {
             const valid = USDateSchema.safeParse(value);
+            const valueParsed = value.replace(/[^0-9]/g, '');
 
             // Update the facade input value, so it let user input wrong/right values.
             setLocalValue(value);
 
+            if (valueParsed.length <= 0) {
+              // A way to make sure the data field state is empty is to empty the value.
+              return handleChangeValueCredential('');
+            }
+
             if (!valid.success) {
-              // A way to make sure the data field state is invalid is to empty the value.
-              return handleChangeValueCredential('-');
+              // A way to make sure the data field state is invalid is to add an invalid date value.
+              return handleChangeValueCredential('NaN');
             }
 
             const date = new Date(value);
             if (date < minDateInstance || date > maxDateInstance) {
-              // A way to make sure the data field state is invalid is to empty the value.
-              return handleChangeValueCredential('-');
+              // A way to make sure the data field state is invalid is to add an invalid date value.
+              return handleChangeValueCredential('NaN');
             }
 
             // Ensures the date is in UTC at noon.

--- a/src/stories/components/form/OneClickForm.stories.tsx
+++ b/src/stories/components/form/OneClickForm.stories.tsx
@@ -414,7 +414,7 @@ function Footer() {
 
 function Component({ data, schemas }: any) {
   return (
-    <Stack width={362} flex={1} mt={1} justifyContent='space-between'>
+    <Stack width={362} flex={1} mt={1}>
       <OneClickForm
         credentials={data.credentials}
         schema={schemas}

--- a/src/stories/components/form/OneClickForm.stories.tsx
+++ b/src/stories/components/form/OneClickForm.stories.tsx
@@ -167,7 +167,7 @@ const mockData = {
       children: [
         {
           type: 'Line1Credential',
-          mandatory: 'if_available',
+          // mandatory: 'no',
           allowUserInput: false,
         },
         {
@@ -178,22 +178,22 @@ const mockData = {
         },
         {
           type: 'CityCredential',
-          mandatory: 'if_available',
+          // mandatory: 'no',
           allowUserInput: false,
         },
         {
           type: 'CountryCredential',
-          mandatory: 'if_available',
+          // mandatory: 'no',
           allowUserInput: false,
         },
         {
           type: 'StateCredential',
-          mandatory: 'if_available',
+          // mandatory: 'no',
           allowUserInput: false,
         },
         {
           type: 'ZipCodeCredential',
-          mandatory: 'if_available',
+          // mandatory: 'no',
           allowUserInput: false,
         },
       ],


### PR DESCRIPTION
## Summary
Improves form field behavior by fixing validation triggers, handling select events properly, and automatically setting edit mode based on mandatory credentials.

## Changes
- 1b1df1c feat: automatically set edit mode based on mandatory credentials
- b528581 fix: handle select event on change value event
- 561650a fix: trigger validation on schema update

## Testing
Locally tested with the OneClickForm component in Storybook to verify all form fields behave correctly, especially with the new Places API integration.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.