### PR TITLE
Fix default edit mode conditional behavior

### DIFF
--- a/src/components/form/OneClickForm/components/CredentialsDisplay/CredentialsDisplayContext.tsx
+++ b/src/components/form/OneClickForm/components/CredentialsDisplay/CredentialsDisplayContext.tsx
@@ -27,7 +27,7 @@ import {
   transformToFormObject,
   transformToFormSchema,
   extractChildrenFromCredentialFieldSet,
-  hasMandatoryCredentialRequests,
+  hasMandatoryFieldEmpty,
 } from './utils';
 
 export type CredentialsDisplayContext = {
@@ -413,7 +413,7 @@ export default function CredentialsDisplayProvider({
 
   // Set initial edit mode based on the presence of mandatory credential requests.
   useLayoutEffect(() => {
-    setEditMode(hasMandatoryCredentialRequests(defaultValues));
+    setEditMode(hasMandatoryFieldEmpty(defaultValues));
   }, [defaultValues]);
 
   return (

--- a/src/components/form/OneClickForm/components/CredentialsDisplay/utils/hasMandatoryFieldEmpty.ts
+++ b/src/components/form/OneClickForm/components/CredentialsDisplay/utils/hasMandatoryFieldEmpty.ts
@@ -5,17 +5,22 @@ import {
   isRequiredCredentialDisplayInfo,
 } from '../utils';
 
-export function hasMandatoryCredentialRequests(
-  fieldSet: CredentialFieldSet,
-): boolean {
+/**
+ * Checks if there is a mandatory field that is empty.
+ *
+ * @param fieldSet The field set to check.
+ * @returns True if there is a mandatory field that is empty, false otherwise.
+ */
+export function hasMandatoryFieldEmpty(fieldSet: CredentialFieldSet): boolean {
   const children = extractChildrenFromCredentialFieldSet(fieldSet);
   const childEntries = Object.entries(children);
   if (!childEntries.length) {
-    return isRequiredCredentialDisplayInfo(
+    const isMandatory = isRequiredCredentialDisplayInfo(
       fieldSet.credentialDisplayInfo.credentialRequest,
     );
+    return isMandatory && !fieldSet.value;
   }
   return childEntries.some(([_, childFieldSet]) =>
-    hasMandatoryCredentialRequests(childFieldSet),
+    hasMandatoryFieldEmpty(childFieldSet),
   );
 }

--- a/src/components/form/OneClickForm/components/CredentialsDisplay/utils/index.ts
+++ b/src/components/form/OneClickForm/components/CredentialsDisplay/utils/index.ts
@@ -15,4 +15,4 @@ export * from './transformToFormSchema';
 export * from './getParentPath';
 export * from './getLastPathName';
 export * from './extractChildrenFromCredentialFieldSet';
-export * from './hasMandatoryCredentialRequests';
+export * from './hasMandatoryFieldEmpty';


### PR DESCRIPTION
## Summary
This PR fixes the form's edit mode initialization to only trigger when mandatory fields are empty.

## Changes
- [130721f] fix: set edit mode initially only if there has some mandatory field empty

## Testing
Locally for Testing.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.