### PR TITLE
fix: export form utils

### DIFF
--- a/src/components/form/OneClickForm/index.tsx
+++ b/src/components/form/OneClickForm/index.tsx
@@ -14,6 +14,7 @@ import {
 } from './types/request';
 
 export * from './components/CredentialsDisplay/types';
+export * from './components/CredentialsDisplay/utils';
 
 type OneClickFormProps = {
   credentialRequests?: CredentialRequests[];


### PR DESCRIPTION
## Summary
This PR exports form utility functions to make them available for external use.

## Changes
- 2c8783e: Export form utilities to make them accessible from outside the package

## Testing
Tested locally by importing and using the exported utilities.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.