### PR TITLE
Add customizable duration prop to AnimateHeight component

### DIFF
--- a/src/components/animation/AnimatedHeight.tsx
+++ b/src/components/animation/AnimatedHeight.tsx
@@ -3,11 +3,19 @@ import { motion } from 'framer-motion';
 
 import { useResizeObserver } from '../../hooks/useResizeObserver';
 
-export function AnimateHeight(props: PropsWithChildren): ReactElement {
+type AnimateHeightProps = {
+  duration?: number;
+};
+
+export function AnimateHeight(
+  props: PropsWithChildren<AnimateHeightProps>,
+): ReactElement {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [, height] = useResizeObserver(containerRef);
   return (
-    <motion.div animate={{ height, transition: { duration: 0.2 } }}>
+    <motion.div
+      animate={{ height, transition: { duration: props.duration ?? 0.2 } }}
+    >
       <div ref={containerRef}>{props.children}</div>
     </motion.div>
   );

--- a/src/stories/components/animation/AnimatedHeight.stories.tsx
+++ b/src/stories/components/animation/AnimatedHeight.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { AnimateHeight } from '../../../components/animation/AnimatedHeight';
 
 const meta = {
@@ -9,27 +9,77 @@ const meta = {
     layout: 'centered',
   },
   tags: ['autodocs'],
+  argTypes: {
+    duration: {
+      control: { type: 'range', min: 0.1, max: 2, step: 0.1 },
+      description: 'Animation duration in seconds',
+      defaultValue: 0.2,
+    },
+  },
 } satisfies Meta<typeof AnimateHeight>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  render: (args) => <DefaultDemo duration={args.duration} />,
   args: {
-    children: (
-      <div style={{ padding: '1rem' }}>
-        <p>This content will animate its height when changed.</p>
-      </div>
-    ),
+    duration: 0.2,
   },
 };
 
+const DefaultDemo = ({ duration }: { duration?: number }) => {
+  const [isVisible, setIsVisible] = useState(true);
+
+  return (
+    <div style={{ width: '300px' }}>
+      <button
+        onClick={() => setIsVisible(!isVisible)}
+        style={{
+          marginBottom: '1rem',
+          padding: '0.5rem 1rem',
+          border: '1px solid #ccc',
+          borderRadius: '4px',
+          cursor: 'pointer',
+        }}
+      >
+        {isVisible ? 'Hide Content' : 'Show Content'}
+      </button>
+      <div
+        style={{
+          padding: '1rem',
+          border: '1px solid #e0e0e0',
+          borderRadius: '4px',
+          background: '#f5f5f5',
+        }}
+      >
+        <h3>Animation Demo</h3>
+        <AnimateHeight duration={duration}>
+          {isVisible && (
+            <div style={{ overflow: 'hidden' }}>
+              <p>This content will animate its height when toggled.</p>
+              <p>
+                Try adjusting the duration control to see different animation
+                speeds.
+              </p>
+            </div>
+          )}
+        </AnimateHeight>
+      </div>
+    </div>
+  );
+};
+
 export const ToggleVisibility: Story = {
-  render: () => <ToggleDemo />,
+  render: (args) => <ToggleDemo duration={args.duration} />,
+  args: {
+    duration: 0.2,
+  },
 };
 
 export const WithDynamicContent: Story = {
   args: {
+    duration: 0.2,
     children: (
       <div style={{ padding: '1rem' }}>
         <p>This is a paragraph that demonstrates the height animation.</p>
@@ -42,7 +92,7 @@ export const WithDynamicContent: Story = {
   },
 };
 
-const ToggleDemo = () => {
+const ToggleDemo = ({ duration }: { duration?: number }) => {
   const [isVisible, setIsVisible] = useState(true);
 
   return (
@@ -68,7 +118,7 @@ const ToggleDemo = () => {
         }}
       >
         <h3>Animated Content</h3>
-        <AnimateHeight>
+        <AnimateHeight duration={duration}>
           {isVisible && (
             <div style={{ overflow: 'hidden' }}>
               <p>This content will smoothly animate in and out when toggled.</p>


### PR DESCRIPTION
## Summary
Adds a customizable duration property to the AnimateHeight component to allow controlling the animation speed.

## Changes
- cd8a04a: fix: expose duration prop - Added duration parameter to AnimateHeight component with a default value of 0.2 seconds
- Updated storybook demo to support and demonstrate the customizable duration

## Testing
Locally for Testing. The component can be tested by adjusting the duration control in the Storybook story.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.