### PR TITLE
Make timezone optional in OneClickOverTimeChart filter interface

### DIFF
--- a/src/components/chart/OneClickOverTimeChart/OneClickOverTimeChart.tsx
+++ b/src/components/chart/OneClickOverTimeChart/OneClickOverTimeChart.tsx
@@ -19,7 +19,7 @@ export interface OneClickOverTimeChartProps {
   isSuccess: boolean;
   isFetching: boolean;
   filter: {
-    timezone: string;
+    timezone?: string;
     brands: BrandFilter[];
   };
 }


### PR DESCRIPTION
## Summary
Make timezone optional in OneClickOverTimeChart filter interface

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
