### PR TITLE
fix: prevent event propagation and remove disabled/readonly states in HeaderSelect

### DIFF
--- a/src/components/form/OneClickForm/components/DataField/DataFieldHeader/HeaderSelect/index.tsx
+++ b/src/components/form/OneClickForm/components/DataField/DataFieldHeader/HeaderSelect/index.tsx
@@ -45,9 +45,13 @@ export function HeaderSelect(): ReactElement {
     variant: 'outlined',
     // When the credential is new, it should display with placeholder the select component.
     value: isNewCredential ? undefined : credentialDisplayInfo.id,
-    onChange: (e) => handleChangeCredentialInstance(e.target.value),
+    onChange: (e) => {
+      // Prevent the event to propagate to the parent.
+      e.stopPropagation();
+      handleChangeCredentialInstance(e.target.value);
+    },
     InputProps: {
-      readOnly: instances.length <= 1,
+      // readOnly: instances.length <= 1,
     },
     SelectProps: {
       size: 'small',
@@ -114,7 +118,7 @@ export function HeaderSelect(): ReactElement {
   return (
     <TextField
       {...textFieldProps}
-      disabled={!allowUserInput && instances.length <= 1}
+      // disabled={!allowUserInput && instances.length <= 1}
     >
       {instances.map(renderInstance(false))}
     </TextField>

--- a/src/components/form/OneClickForm/components/DataField/DataFieldHeader/HeaderSelect/utils/renderInstance.tsx
+++ b/src/components/form/OneClickForm/components/DataField/DataFieldHeader/HeaderSelect/utils/renderInstance.tsx
@@ -140,6 +140,10 @@ export const renderInstance =
         key={credentialDisplayInfo.id}
         value={credentialDisplayInfo.id}
         sx={_styles.menuStyle}
+        onClick={(e) => {
+          // Prevent the event to propagate to the parent.
+          e.stopPropagation();
+        }}
       >
         {renderTextValues(credentialDisplayInfo)}
       </MenuItem>


### PR DESCRIPTION
## Summary

Fixed issue with event propagation in HeaderSelect component and removed disabled/readonly states.

## Changes

- 342a9cb - fix: prevent event propagation and remove disabled/readonly states in HeaderSelect

## Testing

Locally for Testing.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.