### PR TITLE
feat: Implement credential field user input control

### DIFF
--- a/src/components/form/DateInput/index.tsx
+++ b/src/components/form/DateInput/index.tsx
@@ -46,8 +46,10 @@ const GhostInput = forwardRef(function RenderInput(
         edge='end'
         size='small'
         onClick={() => {
+          if (props.disabled) return;
           props.onFocus?.();
         }}
+        disabled={props.disabled}
       >
         <CalendarToday fontSize='small' />
       </IconButton>
@@ -61,12 +63,14 @@ const Picker = function RenderPicker({
   defaultSelectedDate,
   overflow = false,
   clickOutsideBoundaryElement,
+  disabled,
 }: {
   value: string;
   onChange: (event: { target: { value: string } }) => void;
   defaultSelectedDate?: Date;
   overflow?: boolean;
   clickOutsideBoundaryElement?: HTMLElement | null;
+  disabled?: boolean;
 }): ReactElement {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
@@ -174,7 +178,8 @@ const Picker = function RenderPicker({
             setOpen(false);
           }
         }}
-        customInput={<GhostInput />}
+        disabled={disabled}
+        customInput={<GhostInput disabled={disabled} />}
       />
     </Box>
   );
@@ -239,6 +244,7 @@ function DateInputComponent(
             overflow={pickerInputOverflow}
             clickOutsideBoundaryElement={pickerClickOutsideBoundaryElement}
             defaultSelectedDate={pickerDefaultSelectedDate}
+            disabled={disabled}
           />
           {props.InputProps?.endAdornment}
         </>

--- a/src/components/form/OneClickForm/components/CredentialsDisplay/CredentialsDisplayItemContext.tsx
+++ b/src/components/form/OneClickForm/components/CredentialsDisplay/CredentialsDisplayItemContext.tsx
@@ -27,6 +27,7 @@ export type CredentialsDisplayItemContext = {
   isChecked: boolean;
   isAllChecked: boolean;
   isSelectable: boolean;
+  isDisabled: boolean;
   isRoot: boolean;
   handleSelectCredential(checked: boolean, shouldCascade?: boolean): void;
   handleChangeValueCredential(
@@ -213,6 +214,12 @@ export default function CredentialsDisplayItemProvider(
     return cascadeCheck(field);
   }, [JSON.stringify(field)]);
 
+  // Disabled prop that will be passed to the input only,
+  // and not to the field controller as it may set the value to undefined, we do not want that.
+  const isDisabled = useMemo(() => {
+    return !restProps.credentialDisplayInfo?.credentialRequest?.allowUserInput;
+  }, [JSON.stringify(restProps.credentialDisplayInfo)]);
+
   return (
     <Context.Provider
       value={{
@@ -222,6 +229,7 @@ export default function CredentialsDisplayItemProvider(
         isRoot,
         isChecked,
         isAllChecked,
+        isDisabled,
         handleSelectCredential,
         handleChangeCredentialInstance,
         handleChangeValueCredential,

--- a/src/components/form/OneClickForm/components/CredentialsDisplay/components/EditModeButton.tsx
+++ b/src/components/form/OneClickForm/components/CredentialsDisplay/components/EditModeButton.tsx
@@ -1,13 +1,19 @@
 import { ReactElement } from 'react';
 import { Button } from '@mui/material';
 import { Edit } from '@mui/icons-material';
+import { useFormContext } from 'react-hook-form';
 
+import { CredentialFieldSet } from '../types';
+import { isSomeFieldInputAllowed } from '../utils';
 import { useCredentialsDisplay } from '../CredentialsDisplayContext';
 
 export function EditModeButton(): ReactElement | null {
   const context = useCredentialsDisplay();
+  const form = useFormContext<CredentialFieldSet>();
+  const data = form.watch();
+  const shouldShow = isSomeFieldInputAllowed(data);
 
-  if (context.isEditMode) return null;
+  if (context.isEditMode || !shouldShow) return null;
 
   return (
     <Button

--- a/src/components/form/OneClickForm/components/CredentialsDisplay/utils/index.ts
+++ b/src/components/form/OneClickForm/components/CredentialsDisplay/utils/index.ts
@@ -16,3 +16,4 @@ export * from './getParentPath';
 export * from './getLastPathName';
 export * from './extractChildrenFromCredentialFieldSet';
 export * from './hasMandatoryFieldEmpty';
+export * from './isSomeFieldInputAllowed';

--- a/src/components/form/OneClickForm/components/CredentialsDisplay/utils/isSomeFieldInputAllowed.ts
+++ b/src/components/form/OneClickForm/components/CredentialsDisplay/utils/isSomeFieldInputAllowed.ts
@@ -1,0 +1,27 @@
+import { CredentialFieldSet } from '../types';
+
+import { extractChildrenFromCredentialFieldSet } from './extractChildrenFromCredentialFieldSet';
+
+/**
+ * Recursively checks if any child in the credential field set has allowUserInput set to true
+ * in its credentialDisplayInfo.credentialRequest property.
+ */
+export function isSomeFieldInputAllowed(fieldSet: CredentialFieldSet): boolean {
+  const hasEditableChild = (fieldSet: CredentialFieldSet): boolean => {
+    if (fieldSet.type === 'PhoneCredential') return false;
+
+    // Check if current field is editable
+    if (fieldSet.credentialDisplayInfo?.credentialRequest?.allowUserInput) {
+      return true;
+    }
+
+    // Extract all children from the field set
+    const children = extractChildrenFromCredentialFieldSet(fieldSet);
+
+    // Recursively check each child
+    return Object.values(children).some((child) => hasEditableChild(child));
+  };
+
+  // Return true if any child has allowUserInput=true, false otherwise
+  return hasEditableChild(fieldSet);
+}

--- a/src/components/form/OneClickForm/components/CredentialsDisplay/utils/makeCredentialDisplayInfoList.ts
+++ b/src/components/form/OneClickForm/components/CredentialsDisplay/utils/makeCredentialDisplayInfoList.ts
@@ -63,8 +63,8 @@ export const makeCredentialDisplayInfoList = (
       ...credentialRequest,
       mandatory:
         credentialRequest.mandatory ?? options?.mandatory ?? MandatoryEnum.NO,
-      // The SDK currently will allow user input always
-      allowUserInput: true,
+      allowUserInput:
+        credentialRequest.allowUserInput ?? options?.allowUserInput ?? false,
       description,
     };
 
@@ -75,7 +75,8 @@ export const makeCredentialDisplayInfoList = (
     const mapCredentialRequests = (credentialDto: any) => ({
       type: credentialDto.type,
       mandatory: credentialRequest.mandatory,
-      allowUserInput: (options ?? credentialRequest)?.allowUserInput,
+      allowUserInput:
+        credentialRequest.allowUserInput ?? options?.allowUserInput ?? false,
     });
 
     // Make CredentialRequests list from children or from credentials.

--- a/src/components/form/OneClickForm/components/DataField/DataFieldAtomic.tsx
+++ b/src/components/form/OneClickForm/components/DataField/DataFieldAtomic.tsx
@@ -70,7 +70,7 @@ export function DataFieldAtomic(): ReactElement | null {
 
   // Render the given credential, being input mode or display mode.
   const renderField = (): ReactElement | undefined => {
-    if (canEdit && isEditMode) {
+    if (isEditMode) {
       return renderInputField();
     }
 

--- a/src/components/form/OneClickForm/components/DataField/DataFieldAtomic.tsx
+++ b/src/components/form/OneClickForm/components/DataField/DataFieldAtomic.tsx
@@ -1,5 +1,5 @@
 import { ReactElement } from 'react';
-import { Box, Stack, SxProps } from '@mui/material';
+import { Stack, SxProps } from '@mui/material';
 
 import { DisplayFormatEnum } from '../../types/display-format';
 import { credentialTypes } from '../../constants';

--- a/src/components/form/OneClickForm/components/DataField/DataFieldAtomic.tsx
+++ b/src/components/form/OneClickForm/components/DataField/DataFieldAtomic.tsx
@@ -20,7 +20,11 @@ import {
   DataFieldSSNInput,
   DataFieldImageInput,
 } from './inputs';
-import { DataFieldInputModeHeader, DataFieldLeftSide } from './';
+import {
+  DataFieldHeader,
+  DataFieldInputModeHeader,
+  DataFieldLeftSide,
+} from './';
 
 /**
  * This component renders an atomic level credential, it displays the component by displayFormat.
@@ -31,9 +35,6 @@ export function DataFieldAtomic(): ReactElement | null {
   const { credentialDisplayInfo, objectController, parentFieldSet, isRoot } =
     useCredentialsDisplayItem();
   const hasMultipleInstances = credentialDisplayInfo.instances.length > 1;
-  const allowUserInput =
-    credentialDisplayInfo.credentialRequest?.allowUserInput;
-  const canEdit = allowUserInput;
   const isEditMode = credentialDisplayInfo.uiState.isEditMode;
   const fieldType = objectController.field.value.type;
 
@@ -61,6 +62,14 @@ export function DataFieldAtomic(): ReactElement | null {
   // Render data field as read only.
   const renderReadOnlyField = (): ReactElement | undefined => {
     const props = { hasMultipleInstances };
+
+    if (hasMultipleInstances) {
+      return (
+        <When value={isRoot && !isEditMode}>
+          <DataFieldHeader block />
+        </When>
+      );
+    }
 
     return when(credentialDisplayInfo?.displayFormat, {
       [DisplayFormatEnum.Image]: () => <DataFieldImage {...props} />,
@@ -107,10 +116,6 @@ export function DataFieldAtomic(): ReactElement | null {
     >
       <DataFieldLeftSide />
       <Stack direction='column' sx={stackStyle}>
-        {/* When is root data field, display the header. */}
-        <When value={isRoot && !isEditMode}>
-          <Box sx={{ mb: 0.5 }}>{/* <DataFieldHeader block /> */}</Box>
-        </When>
         {/* When is root and edit mode, display the input mode header. */}
         <When value={isRoot && isEditMode}>
           <DataFieldInputModeHeader sx={{ mb: 0.5 }} />

--- a/src/components/form/OneClickForm/components/DataField/DataFieldClearAdornment.tsx
+++ b/src/components/form/OneClickForm/components/DataField/DataFieldClearAdornment.tsx
@@ -16,7 +16,9 @@ type QueryInputReturn =
 export function DataFieldClearAdornment({
   onClick,
 }: DataFieldClearAdornmentProps) {
-  const { handleClearValueCredential } = useCredentialsDisplayItem();
+  const { isDisabled, handleClearValueCredential } =
+    useCredentialsDisplayItem();
+
   const queryInput = (button: HTMLButtonElement): QueryInputReturn => {
     return (
       button.parentElement?.parentElement?.querySelector('input') ??
@@ -32,10 +34,13 @@ export function DataFieldClearAdornment({
         edge='end'
         size='small'
         onClick={(e) => {
+          // Handling disabled state
+          if (isDisabled) return;
           queryInput(e.currentTarget)?.focus();
           handleClearValueCredential();
           onClick?.();
         }}
+        disabled={isDisabled}
       >
         <Close fontSize='small' />
       </IconButton>

--- a/src/components/form/OneClickForm/components/DataField/DataFieldHeader/HeaderSelect/index.tsx
+++ b/src/components/form/OneClickForm/components/DataField/DataFieldHeader/HeaderSelect/index.tsx
@@ -17,9 +17,6 @@ export function HeaderSelect(): ReactElement {
 
   const isNewCredential = isNewCredentialValues(credentialDisplayInfo);
 
-  const allowUserInput =
-    credentialDisplayInfo.credentialRequest?.allowUserInput;
-
   const inputRef = useRef<HTMLDivElement | undefined>(undefined);
   const [inputWidth, setInputWidth] = useState<string | undefined>(undefined);
 
@@ -48,13 +45,19 @@ export function HeaderSelect(): ReactElement {
     onChange: (e) => {
       // Prevent the event to propagate to the parent.
       e.stopPropagation();
+      e.preventDefault();
       handleChangeCredentialInstance(e.target.value);
     },
     InputProps: {
-      readOnly: instances.length <= 1,
+      readOnly: instances.length <= 0,
     },
     SelectProps: {
       size: 'small',
+      onClose: (e) => {
+        // Prevent the event to propagate to the parent.
+        e.stopPropagation();
+        e.preventDefault();
+      },
       MenuProps: {
         slotProps: {
           paper: {
@@ -68,7 +71,7 @@ export function HeaderSelect(): ReactElement {
     sx: {
       width: '100%',
       ..._styles.fieldInputDisabledStyle,
-      ...(instances.length <= 1 && (_styles.fieldInputReadonlyStyle as any)),
+      ...(instances.length <= 0 && (_styles.fieldInputReadonlyStyle as any)),
       '& div[role="combobox"]': {
         width: '100%',
         height: 'auto',
@@ -116,10 +119,7 @@ export function HeaderSelect(): ReactElement {
   }, []);
 
   return (
-    <TextField
-      {...textFieldProps}
-      // disabled={!allowUserInput && instances.length <= 1}
-    >
+    <TextField {...textFieldProps}>
       {instances.map(renderInstance(false))}
     </TextField>
   );

--- a/src/components/form/OneClickForm/components/DataField/DataFieldHeader/HeaderSelect/index.tsx
+++ b/src/components/form/OneClickForm/components/DataField/DataFieldHeader/HeaderSelect/index.tsx
@@ -51,7 +51,7 @@ export function HeaderSelect(): ReactElement {
       handleChangeCredentialInstance(e.target.value);
     },
     InputProps: {
-      // readOnly: instances.length <= 1,
+      readOnly: instances.length <= 1,
     },
     SelectProps: {
       size: 'small',

--- a/src/components/form/OneClickForm/components/DataField/DataFieldRootStack.tsx
+++ b/src/components/form/OneClickForm/components/DataField/DataFieldRootStack.tsx
@@ -18,12 +18,11 @@ export function DataFieldRootStack(props: StackProps): ReactElement {
   const form = useFormContext<CredentialFieldSet>();
   const data = form.watch();
   const shouldShow = isSomeFieldInputAllowed(data);
-
   return (
     <DataFieldStack
       {...props}
       role='button'
-      onClick={() => {
+      onClick={(e) => {
         if (context.isEditMode || !shouldShow) return;
         context.setEditMode(true);
       }}

--- a/src/components/form/OneClickForm/components/DataField/DataFieldRootStack.tsx
+++ b/src/components/form/OneClickForm/components/DataField/DataFieldRootStack.tsx
@@ -1,6 +1,9 @@
 import { ReactElement } from 'react';
 import { StackProps } from '@mui/material';
+import { useFormContext } from 'react-hook-form';
 
+import { CredentialFieldSet } from '../CredentialsDisplay/types';
+import { isSomeFieldInputAllowed } from '../CredentialsDisplay/utils';
 import { useCredentialsDisplay } from '../CredentialsDisplay/CredentialsDisplayContext';
 
 import { DataFieldStack } from './DataFieldStack';
@@ -12,13 +15,16 @@ import { DataFieldStack } from './DataFieldStack';
  */
 export function DataFieldRootStack(props: StackProps): ReactElement {
   const context = useCredentialsDisplay();
+  const form = useFormContext<CredentialFieldSet>();
+  const data = form.watch();
+  const shouldShow = isSomeFieldInputAllowed(data);
 
   return (
     <DataFieldStack
       {...props}
       role='button'
       onClick={() => {
-        if (context.isEditMode) return;
+        if (context.isEditMode || !shouldShow) return;
         context.setEditMode(true);
       }}
     />

--- a/src/components/form/OneClickForm/components/DataField/index.ts
+++ b/src/components/form/OneClickForm/components/DataField/index.ts
@@ -7,3 +7,4 @@ export * from './DataFieldLabel';
 export * from './DataFieldInputModeHeader';
 export * from './DataFieldLeftSide';
 export * from './DataFieldClearAdornment';
+export * from './DataFieldHeader';

--- a/src/components/form/OneClickForm/components/DataField/inputs/DataFieldAddressInput/index.tsx
+++ b/src/components/form/OneClickForm/components/DataField/inputs/DataFieldAddressInput/index.tsx
@@ -112,10 +112,11 @@ const DataFieldAddressInputMemoized = memo(
           value={value}
           inputValue={inputValue}
           loading={isPending || isFetchingPlace}
-          disabled={isFetchingPlace}
+          disabled={isFetchingPlace || credentialsDisplayItem.isDisabled}
           onChange={(event, newValue: string | Option | null) => {
             event.preventDefault();
             event.stopPropagation();
+            if (credentialsDisplayItem.isDisabled) return;
             if (!newValue || typeof newValue === 'string') return;
             handleOptionChange(newValue).catch(console.error);
           }}

--- a/src/components/form/OneClickForm/components/DataField/inputs/DataFieldDateInput.tsx
+++ b/src/components/form/OneClickForm/components/DataField/inputs/DataFieldDateInput.tsx
@@ -81,6 +81,8 @@ const DataFieldDateInputMemoized = memo(
           helperText={credentialDisplayInfo.credentialRequest?.description}
           placeholder='__/__/____'
           onChange={(value) => {
+            if (credentialsDisplayItem.isDisabled) return;
+
             const valid = USDateSchema.safeParse(value);
             const valueParsed = value.replace(/[^0-9]/g, '');
 
@@ -110,7 +112,12 @@ const DataFieldDateInputMemoized = memo(
           }}
           InputProps={{
             endAdornment: (
-              <DataFieldClearAdornment onClick={() => setLocalValue('')} />
+              <DataFieldClearAdornment
+                onClick={() => {
+                  if (credentialsDisplayItem.isDisabled) return;
+                  setLocalValue('');
+                }}
+              />
             ),
           }}
           pickerInputOverflow
@@ -118,6 +125,7 @@ const DataFieldDateInputMemoized = memo(
           pickerClickOutsideBoundaryElement={
             features.datePickerClickOutsideBoundaryElement
           }
+          disabled={credentialsDisplayItem.isDisabled}
         />
       </Box>
     );

--- a/src/components/form/OneClickForm/components/DataField/inputs/DataFieldImageInput.tsx
+++ b/src/components/form/OneClickForm/components/DataField/inputs/DataFieldImageInput.tsx
@@ -78,18 +78,24 @@ const DataFieldImageInputMemoized = memo(
               accept='image/*'
               onChange={(event) => {
                 void (async () => {
+                  if (credentialsDisplayItem.isDisabled) return;
                   const base64 = await handleLoadImageToBase64FromFile(event);
                   if (!base64) return;
                   handleChangeValueCredential(base64);
                 })();
               }}
               sx={{ display: 'none', visibility: 'hidden' }}
+              disabled={credentialsDisplayItem.isDisabled}
             />
             <Button
               color='primary'
               type='button'
-              onClick={() => inputRef.current?.click()}
+              onClick={() => {
+                if (credentialsDisplayItem.isDisabled) return;
+                inputRef.current?.click();
+              }}
               tabIndex={0}
+              disabled={credentialsDisplayItem.isDisabled}
             >
               {credentialDisplayInfo.value ? 'Change Image' : 'Add Image'}
             </Button>

--- a/src/components/form/OneClickForm/components/DataField/inputs/DataFieldPhoneInput.tsx
+++ b/src/components/form/OneClickForm/components/DataField/inputs/DataFieldPhoneInput.tsx
@@ -52,6 +52,7 @@ const DataFieldPhoneInputMemoized = memo(
     }, []);
 
     const handleChange = (newValue: string): void => {
+      if (credentialsDisplayItem.isDisabled) return;
       handleChangeValueCredential(newValue, {
         shouldValidate: newValue.length > 3,
       });
@@ -72,6 +73,7 @@ const DataFieldPhoneInputMemoized = memo(
           InputProps={{
             endAdornment: <DataFieldClearAdornment />,
           }}
+          disabled={credentialsDisplayItem.isDisabled}
         />
       </Box>
     );

--- a/src/components/form/OneClickForm/components/DataField/inputs/DataFieldSSNInput.tsx
+++ b/src/components/form/OneClickForm/components/DataField/inputs/DataFieldSSNInput.tsx
@@ -33,6 +33,7 @@ const DataFieldSSNInputMemoized = memo(
     const value = objectController.field.value.value;
 
     const handleChange = (event: { target: { value: string } }): void => {
+      if (credentialsDisplayItem.isDisabled) return;
       handleChangeValueCredential(event.target.value, {
         shouldValidate: event.target.value.length > 0,
       });
@@ -56,6 +57,7 @@ const DataFieldSSNInputMemoized = memo(
               />
             ),
           }}
+          disabled={credentialsDisplayItem.isDisabled}
         />
       </Box>
     );

--- a/src/components/form/OneClickForm/components/DataField/inputs/DataFieldSelectInput.tsx
+++ b/src/components/form/OneClickForm/components/DataField/inputs/DataFieldSelectInput.tsx
@@ -31,7 +31,7 @@ export function DataFieldSelectInput() {
     handleClearValueCredential,
   } = credentialsDisplayItem;
 
-  const { isValid, errorMessage } = useCredentialsDisplayItemValid();
+  const { isValid } = useCredentialsDisplayItemValid();
 
   const schemaProperty = findCorrectSchemaProperty(
     credentialDisplayInfo.schema,
@@ -160,8 +160,9 @@ export function DataFieldSelectInput() {
         isOptionEqualToValue={(option, value) => option?.id === value?.id}
         value={value}
         onChange={(_event, newInputValue) => {
-          // User clicked on clear button.
+          if (credentialsDisplayItem.isDisabled) return;
           if (!newInputValue) {
+            // User clicked on clear button.
             handleClearValueCredential();
             return;
           }
@@ -178,6 +179,7 @@ export function DataFieldSelectInput() {
             }}
           />
         )}
+        disabled={credentialsDisplayItem.isDisabled}
       />
     </Box>
   );

--- a/src/components/form/OneClickForm/components/DataField/inputs/DataFieldTextInput.tsx
+++ b/src/components/form/OneClickForm/components/DataField/inputs/DataFieldTextInput.tsx
@@ -66,7 +66,10 @@ const DataFieldTextInputMemoized = memo(
       ),
       label: <DataFieldLabelText />,
       defaultValue: objectController.field.value.value || '',
-      onChange: (e) => handleChangeDebouncedValueCredential(e.target.value),
+      onChange: (e) => {
+        if (credentialsDisplayItem.isDisabled) return;
+        handleChangeDebouncedValueCredential(e.target.value);
+      },
       error: !itemValid.isValid,
       helperText:
         credentialsDisplayItem.credentialDisplayInfo.credentialRequest
@@ -92,6 +95,7 @@ const DataFieldTextInputMemoized = memo(
         autoCapitalize: 'off',
       },
       fullWidth: true,
+      disabled: credentialsDisplayItem.isDisabled,
     };
 
     return (

--- a/src/stories/components/form/OneClickForm.stories.tsx
+++ b/src/stories/components/form/OneClickForm.stories.tsx
@@ -342,6 +342,19 @@ const mockData = {
       },
     },
     {
+      id: '99fb267d-c1d0-4b12-a296-5533317dc5c2',
+      uuid: '10a9e718-e20a-4179-8774-54a25f73eab6',
+      createdAt: '1738698702792',
+      updatedAt: '1738698702792',
+      type: 'SsnCredential',
+      issuanceDate: '1738698702792',
+      expirationDate: null,
+      issuerUuid: '2f842399-4220-434d-920d-8b41319cf5db',
+      data: {
+        ssn: '•••-••-6788',
+      },
+    },
+    {
       id: '3c145728-0df2-4207-94a2-7fad69b74f04',
       uuid: '27c6504c-25c2-46e2-90ff-bd5a8064b51c',
       createdAt: '1738698702792',

--- a/src/stories/components/form/OneClickForm.stories.tsx
+++ b/src/stories/components/form/OneClickForm.stories.tsx
@@ -135,7 +135,7 @@ const mockData = {
   },
   credentialRequests: [
     {
-      allowUserInput: false,
+      allowUserInput: true,
       mandatory: 'if_available',
       multi: false,
       type: 'FullNameCredential',
@@ -143,13 +143,13 @@ const mockData = {
         {
           type: 'FirstNameCredential',
           mandatory: 'if_available',
-          allowUserInput: false,
+          // allowUserInput: false,
         },
         // { type: 'MiddleNameCredential', mandatory: 'no', allowUserInput: false },
         {
           type: 'LastNameCredential',
           mandatory: 'if_available',
-          allowUserInput: false,
+          // allowUserInput: false,
         },
       ],
     },


### PR DESCRIPTION
## Summary

This PR implements the ability to control whether credential fields can be edited by users based on an "allowUserInput" property in credential requests.

## Changes

- feat: Implement input disabled state based on allowUserInput credential request property (6728641)
- refactor: Refactor DataField header and select components for better event handling (3b886e0)
- chore: Remove unused component (94de56f)

## Testing

Locally for Testing. The OneClickForm component can be tested with various credential configurations to verify that fields are properly enabled/disabled based on the allowUserInput property.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.