### PR TITLE
fix: Add margin top spacing to DataFieldRootStack component to prevent from clipping label

### DIFF
--- a/src/components/form/OneClickForm/components/CredentialsDisplay/CredentialsDisplay.tsx
+++ b/src/components/form/OneClickForm/components/CredentialsDisplay/CredentialsDisplay.tsx
@@ -79,7 +79,7 @@ export default function CredentialsDisplay(): ReactElement {
         sx={{ flex: 1, width: '100%' }}
       >
         <EditModeButton />
-        <DataFieldRootStack>
+        <DataFieldRootStack sx={{ mt: 0.75 }}>
           {Object.entries(data).map((entry) =>
             renderCredentialDisplayInfo(entry),
           )}


### PR DESCRIPTION
## Summary

Added margin top spacing to the DataFieldRootStack component to prevent the label from being clipped.

## Changes

- fix: Add margin top spacing to DataFieldRootStack component to prevent from clipping label (21e4b71)

## Testing

Locally for Testing.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
