### PR TITLE
Lower motion peer dependency and fix component type exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "@mui/material": ">=5 <6",
         "@tanstack/react-query": ">=5",
         "decimal.js": ">=10.4.3",
-        "framer-motion": ">=11.15.0",
+        "framer-motion": ">=11.11.1",
         "immer": ">=10",
         "libphonenumber-js": ">=1.11.11",
         "notistack": ">=3.0.1",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@mui/material": ">=5 <6",
     "@tanstack/react-query": ">=5",
     "decimal.js": ">=10.4.3",
-    "framer-motion": ">=11.15.0",
+    "framer-motion": ">=11.11.1",
     "immer": ">=10",
     "libphonenumber-js": ">=1.11.11",
     "notistack": ">=3.0.1",

--- a/src/components/animation/motions.ts
+++ b/src/components/animation/motions.ts
@@ -7,56 +7,32 @@ import {
   Typography,
   Stack,
 } from '@mui/material';
-import type {
-  BoxProps,
-  ButtonProps,
-  TableBodyProps,
-  TableCellProps,
-  TableRowProps,
-  TypographyProps,
-  StackProps,
-} from '@mui/material';
 import { motion } from 'framer-motion';
 
-export const MotionBox = motion.create(
-  Box as React.ForwardRefExoticComponent<BoxProps>,
-);
+export const MotionBox = motion.create(Box as any, {
+  forwardMotionProps: false,
+});
 
-export const MotionStack = motion.create(
-  Stack as React.ForwardRefExoticComponent<StackProps>,
-);
+export const MotionStack = motion.create(Stack as any, {
+  forwardMotionProps: false,
+});
 
-export const MotionTbody = motion.create(
-  TableBody as React.ForwardRefExoticComponent<TableBodyProps>,
-  {
-    forwardMotionProps: false,
-  },
-);
+export const MotionTbody = motion.create(TableBody as any, {
+  forwardMotionProps: false,
+});
 
-export const MotionTableRow = motion.create(
-  TableRow as React.ForwardRefExoticComponent<TableRowProps>,
-  {
-    forwardMotionProps: false,
-  },
-);
+export const MotionTableRow = motion.create(TableRow as any, {
+  forwardMotionProps: false,
+});
 
-export const MotionTableCell = motion.create(
-  TableCell as React.ForwardRefExoticComponent<TableCellProps>,
-  {
-    forwardMotionProps: false,
-  },
-);
+export const MotionTableCell = motion.create(TableCell as any, {
+  forwardMotionProps: false,
+});
 
-export const MotionTypography = motion.create(
-  Typography as React.ForwardRefExoticComponent<TypographyProps>,
-  {
-    forwardMotionProps: false,
-  },
-);
+export const MotionTypography = motion.create(Typography as any, {
+  forwardMotionProps: false,
+});
 
-export const MotionButton = motion.create(
-  Button as React.ForwardRefExoticComponent<ButtonProps>,
-  {
-    forwardMotionProps: false,
-  },
-);
+export const MotionButton = motion.create(Button as any, {
+  forwardMotionProps: false,
+});

--- a/src/components/animation/motions.ts
+++ b/src/components/animation/motions.ts
@@ -9,7 +9,7 @@ import {
 } from '@mui/material';
 import { motion } from 'framer-motion';
 
-export const MotionBox = motion.create(Box as any, {
+export const MotionBox = motion.create(Box as React.ComponentType<any>, {
   forwardMotionProps: false,
 });
 


### PR DESCRIPTION
## Summary
<!---
1-2 sentences summarizing the changes included in this PR
--->
This PR lowers the peer dependency requirement for framer-motion from >=11.15.0 to >=11.11.1 and simplifies motion component exports by using type assertions to prevent unknown build errors.

## Changes
<!---
List all non-trivial changes included in this PR. Bullet points are fine or the individual commits that make up this PR.
--->
- Reduced the minimum version requirement for framer-motion from >=11.15.0 to >=11.11.1 in both package.json and package-lock.json
- Removed specific type imports from '@mui/material' that were no longer needed
- Changed motion component implementations to use `as any` type assertion instead of explicit ForwardRefExoticComponent typing
- Applied consistent `forwardMotionProps: false` option to all motion components

## Testing
<!---
How did you test your changes? How might someone else test them?
--->
The changes can be tested by importing and using motion components with the lower framer-motion version to ensure they render correctly.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.