### PR TITLE
Simplify type casting in motion components

### DIFF
--- a/src/components/animation/motions.ts
+++ b/src/components/animation/motions.ts
@@ -9,30 +9,30 @@ import {
 } from '@mui/material';
 import { motion } from 'framer-motion';
 
-export const MotionBox = motion(Box as React.ComponentType<any>, {
+export const MotionBox = motion(Box as any, {
   forwardMotionProps: false,
 });
 
-export const MotionStack = motion(Stack as React.ComponentType<any>, {
+export const MotionStack = motion(Stack as any, {
   forwardMotionProps: false,
 });
 
-export const MotionTbody = motion(TableBody as React.ComponentType<any>, {
+export const MotionTbody = motion(TableBody as any, {
   forwardMotionProps: false,
 });
 
-export const MotionTableRow = motion(TableRow as React.ComponentType<any>, {
+export const MotionTableRow = motion(TableRow as any, {
   forwardMotionProps: false,
 });
 
-export const MotionTableCell = motion(TableCell as React.ComponentType<any>, {
+export const MotionTableCell = motion(TableCell as any, {
   forwardMotionProps: false,
 });
 
-export const MotionTypography = motion(Typography as React.ComponentType<any>, {
+export const MotionTypography = motion(Typography as any, {
   forwardMotionProps: false,
 });
 
-export const MotionButton = motion(Button as React.ComponentType<any>, {
+export const MotionButton = motion(Button as any, {
   forwardMotionProps: false,
 });


### PR DESCRIPTION
## Summary
Fix type casting in motion components by simplifying the casting from `React.ComponentType<any>` to just `any`.

## Changes
- Simplified type casting in all motion component definitions (MotionBox, MotionStack, MotionTbody, MotionTableRow, MotionTableCell, MotionTypography, and MotionButton)
- Changed from `motion(Component as React.ComponentType<any>, {` to `motion(Component as any, {` for all components
- This change maintains the same functionality while using a simpler type casting approach

## Testing
N/A

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.