### PR TITLE
Add disabled state handling to RadioOption component

### DIFF
--- a/src/components/form/RadioOption.tsx
+++ b/src/components/form/RadioOption.tsx
@@ -52,6 +52,7 @@ export function RadioOption(props: RadioOptionProps) {
           <Radio
             checked={checked}
             onChange={handleCheck}
+            disabled={disabled}
             {...radioProps}
             sx={{
               mt: '1px',
@@ -62,7 +63,14 @@ export function RadioOption(props: RadioOptionProps) {
               },
             }}
           />
-          <Stack onClick={handleCheck} sx={{ cursor: 'pointer' }}>
+          <Stack
+            onClick={handleCheck}
+            sx={{
+              cursor: 'pointer',
+              opacity: disabled ? 0.4 : 1,
+              pointerEvents: disabled ? 'none' : 'auto',
+            }}
+          >
             <Stack direction='row' alignItems='center' spacing={1}>
               <Typography
                 variant='body1'

--- a/src/components/form/RadioOption.tsx
+++ b/src/components/form/RadioOption.tsx
@@ -64,9 +64,9 @@ export function RadioOption(props: RadioOptionProps) {
             }}
           />
           <Stack
-            onClick={handleCheck}
+            onClick={disabled ? undefined : handleCheck}
             sx={{
-              cursor: 'pointer',
+              cursor: disabled ? 'default' : 'pointer',
               opacity: disabled ? 0.4 : 1,
               pointerEvents: disabled ? 'none' : 'auto',
             }}


### PR DESCRIPTION
## Summary
Add proper disabled state handling for RadioOption component

## Changes
- Added `disabled` prop to the Radio component
- Enhanced Stack component styling to properly handle disabled states:
  - Added opacity change (0.4) when disabled
  - Added pointer-events control to prevent interaction when disabled
  - Maintained the cursor style for enabled state

## Testing
Manual testing can be performed by:
- Adding a RadioOption component with `disabled={true}` prop
- Verifying that the component appears faded and is not interactive

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.