### PR TITLE
Add support for credential field descriptions

### DIFF
--- a/src/components/form/OneClickForm/components/DataField/DataFieldDescription.tsx
+++ b/src/components/form/OneClickForm/components/DataField/DataFieldDescription.tsx
@@ -1,0 +1,22 @@
+import { Typography } from '@mui/material';
+
+import { useCredentialsDisplayItem } from '../CredentialsDisplay/CredentialsDisplayItemContext';
+
+export function DataFieldDescription() {
+  const { credentialDisplayInfo } = useCredentialsDisplayItem();
+  return (
+    <Typography
+      variant='body1'
+      color='text.secondary'
+      sx={{
+        fontSize: 12,
+        fontWeight: 400,
+        wordBreak: 'break-word',
+        mt: 0.5,
+        mr: 1.75,
+      }}
+    >
+      {credentialDisplayInfo.credentialRequest?.description}
+    </Typography>
+  );
+}

--- a/src/components/form/OneClickForm/components/DataField/DataFieldHeader/HeaderSelect/index.tsx
+++ b/src/components/form/OneClickForm/components/DataField/DataFieldHeader/HeaderSelect/index.tsx
@@ -46,6 +46,7 @@ export function HeaderSelect(): ReactElement {
         : `Select ${credentialDisplayInfo.label}`,
     // When the credential is new, it should display with placeholder the select component.
     value: isNewCredential ? undefined : credentialDisplayInfo.id,
+    helperText: credentialDisplayInfo.credentialRequest.description,
     onChange: (e) => {
       // Prevent the event to propagate to the parent.
       e.stopPropagation();
@@ -97,6 +98,9 @@ export function HeaderSelect(): ReactElement {
       '& .Mui-disabled': {
         color: (theme) => `${theme.palette.text.primary}`,
         WebkitTextFillColor: (theme) => `${theme.palette.text.primary}`,
+      },
+      '& .MuiFormHelperText-root': {
+        ml: instances.length <= 1 ? 0 : undefined,
       },
     },
   };

--- a/src/components/form/OneClickForm/components/DataField/formats/DataFieldText.tsx
+++ b/src/components/form/OneClickForm/components/DataField/formats/DataFieldText.tsx
@@ -7,6 +7,8 @@ import { useCredentialsDisplayItem } from '../../CredentialsDisplay/CredentialsD
 
 import { DataFieldLabel, DataFieldValue } from '../';
 
+import { DataFieldDescription } from '../DataFieldDescription';
+
 /**
  * This component renders and manages the input value for display format Text or to strings.
  * @constructor
@@ -22,7 +24,10 @@ export function DataFieldText(): ReactElement {
     <div style={{ width: '100%' }}>
       <Stack direction='row' width='100%'>
         <DataFieldLabel />
-        <DataFieldValue>{formattedValue}</DataFieldValue>
+        <Stack direction='column'>
+          <DataFieldValue>{formattedValue}</DataFieldValue>
+          <DataFieldDescription />
+        </Stack>
       </Stack>
     </div>
   );

--- a/src/stories/components/form/OneClickForm.stories.tsx
+++ b/src/stories/components/form/OneClickForm.stories.tsx
@@ -143,12 +143,14 @@ const mockData = {
         {
           type: 'FirstNameCredential',
           mandatory: 'if_available',
+          description: 'Your first name',
           // allowUserInput: false,
         },
         // { type: 'MiddleNameCredential', mandatory: 'no', allowUserInput: false },
         {
           type: 'LastNameCredential',
           mandatory: 'if_available',
+          description: 'Your last name',
           // allowUserInput: false,
         },
       ],
@@ -164,6 +166,7 @@ const mockData = {
       mandatory: 'if_available',
       multi: true,
       type: 'AddressCredential',
+      description: 'Shipping address',
       children: [
         {
           type: 'Line1Credential',
@@ -210,6 +213,7 @@ const mockData = {
       mandatory: 'if_available',
       multi: false,
       type: 'SsnCredential',
+      description: 'Last 4 digits',
     },
     // {
     //   allowUserInput: true,

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -333,6 +333,13 @@ export const theme = ({ primaryFontFace, ...options }: ThemeOptionsProps) =>
           size: 'medium',
         },
       },
+      MuiFormHelperText: {
+        styleOverrides: {
+          root: {
+            wordBreak: 'break-word',
+          },
+        },
+      },
     },
     ...options,
   });


### PR DESCRIPTION
## Summary
This PR adds support for credential field descriptions that display below form fields, improving the UX by providing additional context to users about what information is being requested.

## Changes
- Created a new `DataFieldDescription` component that renders description text for form fields
- Integrated the description component into `DataFieldText` component
- Added `helperText` support in the `HeaderSelect` component to display descriptions
- Updated theme styling for `MuiFormHelperText` to handle word breaking
- Added example descriptions in the OneClickForm stories

## Testing
The changes can be tested by:
- Viewing the OneClickForm storybook examples with new description fields
- Verifying that descriptions appear correctly below form fields
- Checking that text breaks properly for longer descriptions

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.