### PR TITLE
Switch credential requests editor from blacklist to whitelist approach

### DIFF
--- a/src/components/CredentialRequestsEditor/components/DataFieldOptionType.tsx
+++ b/src/components/CredentialRequestsEditor/components/DataFieldOptionType.tsx
@@ -30,6 +30,7 @@ export function DataFieldOptionType(): React.JSX.Element {
         id: schema.$id as string,
       }))
       .filter((schema) => {
+        // Allow only supported credentials. Ref: https://docs.verified.inc/data/outputs/credentials#core-kyc
         const whitelist = [
           'AddressCredential',
           'Line1Credential',

--- a/src/components/CredentialRequestsEditor/components/DataFieldOptionType.tsx
+++ b/src/components/CredentialRequestsEditor/components/DataFieldOptionType.tsx
@@ -30,8 +30,24 @@ export function DataFieldOptionType(): React.JSX.Element {
         id: schema.$id as string,
       }))
       .filter((schema) => {
-        const blacklist = ['IdentityCredential'];
-        return !blacklist.includes(schema.id);
+        const whitelist = [
+          'AddressCredential',
+          'Line1Credential',
+          'Line2Credential',
+          'CityCredential',
+          'StateCredential',
+          'CountryCredential',
+          'ZipCodeCredential',
+          'FullNameCredential',
+          'FirstNameCredential',
+          'MiddleNameCredential',
+          'LastNameCredential',
+          'PhoneCredential',
+          'BirthDateCredential',
+          'SsnCredential',
+          'GenderCredential',
+        ];
+        return whitelist.includes(schema.id);
       })
       .sort((a, b) => (a.label < b.label ? -1 : 1));
   }, [schemas]);


### PR DESCRIPTION
## Summary
Switch from blacklist to whitelist approach in credential requests editor, explicitly defining allowed credential types.

## Changes
- Changed the filtering logic in `DataFieldOptionType.tsx` from a blacklist approach to a whitelist approach
- Added explicit list of allowed credential types (address-related, name-related, and other personal credentials)
- This ensures only specific credential types can be selected in the editor

## Testing
N/A

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.