### PR TITLE
Make Google Places service response format agnostic

### DIFF
--- a/src/components/form/AddressInput/autofill.hook.ts
+++ b/src/components/form/AddressInput/autofill.hook.ts
@@ -131,16 +131,11 @@ export function useAutoFill(): AutoFillHookReturn {
         return;
       }
 
-      if (!result || autoCompleteError) {
-        setIsPending(false);
-        return;
-      }
-
       // Add type validation before casting
       if (Array.isArray(result)) {
         setSuggestions(result as PlaceSuggestion[]);
       } else {
-        console.error('Unexpected response format from Google Places API');
+        // Bad implementation, return empty array
         setSuggestions([]);
       }
     } catch (error) {
@@ -148,8 +143,6 @@ export function useAutoFill(): AutoFillHookReturn {
       if (error instanceof DOMException && error.name === 'AbortError') {
         return;
       }
-      // Otherwise, handle other errors
-      console.error('Failed to fetch address suggestions:', error);
     } finally {
       // Only clear isPending if this is still the most recent request
       if (abortControllerRef.current === abortController) {
@@ -172,7 +165,12 @@ export function useAutoFill(): AutoFillHookReturn {
       return null;
     }
 
-    return result as PlaceAddressComponent[];
+    // Add type validation before casting
+    if (result && Array.isArray(result)) {
+      return result as PlaceAddressComponent[];
+    }
+
+    return null;
   };
 
   return {

--- a/src/components/form/AddressInput/autofill.hook.ts
+++ b/src/components/form/AddressInput/autofill.hook.ts
@@ -117,9 +117,8 @@ export function useAutoFill(): AutoFillHookReturn {
         return;
       }
 
-      const response = await googlePlacesAutocompletePlaces(
-        value,
-        abortController.signal,
+      const [result, autoCompleteError] = await wrapPromise(
+        googlePlacesAutocompletePlaces(value, abortController.signal),
       );
 
       // If the request was aborted, don't proceed
@@ -127,23 +126,12 @@ export function useAutoFill(): AutoFillHookReturn {
         return;
       }
 
-      if (!response.ok) {
+      if (!result || autoCompleteError) {
         setIsPending(false);
         return;
       }
 
-      const [result, error] = await wrapPromise<PlaceSuggestion[]>(
-        response.json(),
-      );
-
-      // Check again if aborted after the json parsing
-      if (abortController.signal.aborted) {
-        return;
-      }
-
-      if (!error) {
-        setSuggestions(result);
-      }
+      setSuggestions(result as PlaceSuggestion[]);
     } catch (error) {
       // If the error is due to abortion, we can silently ignore it
       if (error instanceof DOMException && error.name === 'AbortError') {
@@ -165,19 +153,15 @@ export function useAutoFill(): AutoFillHookReturn {
   ): Promise<PlaceAddressComponent[] | null> => {
     if (!googlePlacesGetPlace) return null;
 
-    const response = await googlePlacesGetPlace(placeId, signal);
+    const [result, getPlaceError] = await wrapPromise(
+      googlePlacesGetPlace(placeId, signal),
+    );
 
-    if (!response.ok) {
+    if (getPlaceError) {
       return null;
     }
 
-    const [result, error] = await wrapPromise(response.json());
-
-    if (!error) {
-      return result;
-    }
-
-    return null;
+    return result as PlaceAddressComponent[];
   };
 
   return {

--- a/src/components/form/AddressInput/autofill.hook.ts
+++ b/src/components/form/AddressInput/autofill.hook.ts
@@ -131,7 +131,18 @@ export function useAutoFill(): AutoFillHookReturn {
         return;
       }
 
-      setSuggestions(result as PlaceSuggestion[]);
+      if (!result || autoCompleteError) {
+        setIsPending(false);
+        return;
+      }
+
+      // Add type validation before casting
+      if (Array.isArray(result)) {
+        setSuggestions(result as PlaceSuggestion[]);
+      } else {
+        console.error('Unexpected response format from Google Places API');
+        setSuggestions([]);
+      }
     } catch (error) {
       // If the error is due to abortion, we can silently ignore it
       if (error instanceof DOMException && error.name === 'AbortError') {

--- a/src/components/form/AddressInput/context.tsx
+++ b/src/components/form/AddressInput/context.tsx
@@ -4,11 +4,11 @@ interface AddressInputContextType {
   googlePlacesAutocompletePlaces?: (
     input: string,
     signal?: AbortSignal,
-  ) => Promise<Response>;
+  ) => Promise<unknown>;
   googlePlacesGetPlace?: (
     placeId: string,
     signal?: AbortSignal,
-  ) => Promise<Response>;
+  ) => Promise<unknown>;
 }
 
 const defaultContextValue: AddressInputContextType = {
@@ -24,11 +24,11 @@ interface AddressInputProviderProps {
   googlePlacesAutocompletePlaces?: (
     input: string,
     signal?: AbortSignal,
-  ) => Promise<Response>;
+  ) => Promise<unknown>;
   googlePlacesGetPlace?: (
     placeId: string,
     signal?: AbortSignal,
-  ) => Promise<Response>;
+  ) => Promise<unknown>;
 }
 
 export function AddressInputProvider({

--- a/src/components/form/AddressInput/index.tsx
+++ b/src/components/form/AddressInput/index.tsx
@@ -39,11 +39,11 @@ export type AddressInputProps = {
     googlePlacesAutocompletePlaces?: (
       input: string,
       signal?: AbortSignal,
-    ) => Promise<Response>;
+    ) => Promise<unknown>;
     googlePlacesGetPlace?: (
       placeId: string,
       signal?: AbortSignal,
-    ) => Promise<Response>;
+    ) => Promise<unknown>;
   };
 };
 

--- a/src/stories/components/form/AddressInput.stories.tsx
+++ b/src/stories/components/form/AddressInput.stories.tsx
@@ -14,14 +14,18 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { action } from '@storybook/addon-actions';
 
 import { AddressInput } from '../../../components/form/AddressInput';
-import { Address } from '../../../components/form/AddressInput/types';
+import {
+  Address,
+  PlaceSuggestion,
+  PlaceAddressComponent,
+} from '../../../components/form/AddressInput/types';
 
 // Fetcher functions for Storybook using real API endpoints
 const googlePlacesAutocompletePlaces = async (
   input: string,
   signal?: AbortSignal,
-): Promise<Response> => {
-  return fetch(
+): Promise<PlaceSuggestion[]> => {
+  const response = await fetch(
     'http://localhost:3070/api/googleapis/places/AutocompletePlaces',
     {
       method: 'POST',
@@ -32,20 +36,35 @@ const googlePlacesAutocompletePlaces = async (
       signal,
     },
   );
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  return response.json();
 };
 
 const googlePlacesGetPlace = async (
   placeId: string,
   signal?: AbortSignal,
-): Promise<Response> => {
-  return fetch('http://localhost:3070/api/googleapis/places/GetPlace', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
+): Promise<PlaceAddressComponent[]> => {
+  const response = await fetch(
+    'http://localhost:3070/api/googleapis/places/GetPlace',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name: placeId }),
+      signal,
     },
-    body: JSON.stringify({ name: placeId }),
-    signal,
-  });
+  );
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  return response.json();
 };
 
 // Simple clear adornment component for stories

--- a/src/stories/components/form/AddressInput.stories.tsx
+++ b/src/stories/components/form/AddressInput.stories.tsx
@@ -38,7 +38,7 @@ const googlePlacesAutocompletePlaces = async (
   );
 
   if (!response.ok) {
-throw new Error(`AutocompletePlaces API error! status: ${response.status}`);
+    throw new Error(`AutocompletePlaces API error! status: ${response.status}`);
   }
 
   return response.json();

--- a/src/stories/components/form/AddressInput.stories.tsx
+++ b/src/stories/components/form/AddressInput.stories.tsx
@@ -38,7 +38,7 @@ const googlePlacesAutocompletePlaces = async (
   );
 
   if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
+throw new Error(`AutocompletePlaces API error! status: ${response.status}`);
   }
 
   return response.json();


### PR DESCRIPTION
## Summary
This PR makes the Google Places service response format agnostic by changing the return types from `Promise<Response>` to `Promise<unknown>` and updating the implementation to handle parsed data directly.

## Changes
- Modified the return type of Google Places API functions from `Promise<Response>` to `Promise<unknown>` in type definitions
- Updated the autofill hook to handle direct data responses rather than having to parse Response objects
- Refactored the implementation in stories to return parsed data (typed objects) instead of Response objects
- Improved error handling in the Google Places API integration

## Testing
Storybook and Dashboard client.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.