### PR TITLE
Fix UTC date handling in DataFieldDateInput component

### DIFF
--- a/src/components/form/OneClickForm/components/DataField/inputs/DataFieldDateInput.tsx
+++ b/src/components/form/OneClickForm/components/DataField/inputs/DataFieldDateInput.tsx
@@ -99,14 +99,14 @@ const DataFieldDateInputMemoized = memo(
               return handleChangeValueCredential('NaN');
             }
 
-            const date = new Date(value);
+            // Parse the date string (MM/DD/YYYY) and create a UTC date
+            const [month, day, year] = value.split('/').map(Number);
+            const date = new Date(Date.UTC(year, month - 1, day, 12, 0, 0, 0));
+
             if (date < minDateInstance || date > maxDateInstance) {
               // A way to make sure the data field state is invalid is to add an invalid date value.
               return handleChangeValueCredential('NaN');
             }
-
-            // Ensures the date is in UTC at noon.
-            date.setUTCHours(12);
 
             handleChangeValueCredential(String(+date));
           }}


### PR DESCRIPTION
## Summary
<!---
1-2 sentences summarizing the changes included in this PR
--->
This PR fixes date handling in DataFieldDateInput component by ensuring proper UTC date creation from MM/DD/YYYY format strings instead of relying on implicit date conversion.

## Changes
<!---
List all non-trivial changes included in this PR. Bullet points are fine or the individual commits that make up this PR.
--->
- Modified date parsing logic in DataFieldDateInput.tsx to explicitly split date strings by '/' and create UTC dates
- Replaced the post-creation UTC hours adjustment with a direct UTC date creation approach
- Added more descriptive comments about the date parsing process

## Testing
<!---
How did you test your changes? How might someone else test them?
--->
The changes can be tested by entering various date values in the OneClickForm component's date fields and verifying that the dates are correctly interpreted regardless of the user's timezone.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.