### PR TITLE
Add US territories and improve state list alphabetical sorting

### DIFF
--- a/src/components/form/NewOneClickForm/core/shared/us-states.ts
+++ b/src/components/form/NewOneClickForm/core/shared/us-states.ts
@@ -7,7 +7,6 @@ export const US_STATES_RECORD = {
   CO: 'Colorado',
   CT: 'Connecticut',
   DE: 'Delaware',
-  DC: 'District of Columbia',
   FL: 'Florida',
   GA: 'Georgia',
   HI: 'Hawaii',
@@ -45,12 +44,18 @@ export const US_STATES_RECORD = {
   TX: 'Texas',
   UT: 'Utah',
   VT: 'Vermont',
-  VI: 'Virgin Islands',
   VA: 'Virginia',
   WA: 'Washington',
   WV: 'West Virginia',
   WI: 'Wisconsin',
   WY: 'Wyoming',
+  DC: 'District of Columbia',
+  AS: 'American Samoa',
+  GU: 'Guam',
+  MP: 'Northern Mariana Islands',
+  PR: 'Puerto Rico',
+  UM: 'United States Minor Outlying Islands',
+  VI: 'Virgin Islands',
 } as const;
 
 export type USStateCode = keyof typeof US_STATES_RECORD;
@@ -60,12 +65,15 @@ export type USStateName = (typeof US_STATES_RECORD)[USStateCode];
  * US States and Territories with their ISO 3166-2 codes
  * Used for state selection when country is US
  */
-export const US_STATES = Object.entries(US_STATES_RECORD).map(
-  ([code, name]) => ({
+export const US_STATES = Object.entries(US_STATES_RECORD)
+  .map(([code, name]) => ({
     value: code,
     label: name,
-  }),
-) as Array<{ value: USStateCode; label: USStateName }>;
+  }))
+  .sort((a, b) => a.label.localeCompare(b.label)) as Array<{
+  value: USStateCode;
+  label: USStateName;
+}>;
 
 export const US_STATE_CODES = Object.keys(US_STATES_RECORD) as USStateCode[];
 export const US_STATE_NAMES = Object.values(US_STATES_RECORD) as USStateName[];


### PR DESCRIPTION
- Removed 'District of Columbia' from the initial list and added it back at the end.
- Added new territories: 'American Samoa', 'Guam', 'Northern Mariana Islands', 'Puerto Rico', and 'United States Minor Outlying Islands'.
- Updated sorting logic for the US_STATES export to sort by state name.

Summary
======
<!---
1-2 sentences summarizing the changes included in this PR
--->

Updated US states enumeration to include US territories and improved sorting logic to alphabetically order states by name instead of by code.

Changes
======
<!---
List all non-trivial changes included in this PR. Bullet points are fine or the individual commits that make up this PR.
--->

- Reorganized states list by moving 'District of Columbia' from its original position to be grouped with territories
- Added previously missing US territories:
  - American Samoa (AS)
  - Guam (GU)
  - Northern Mariana Islands (MP)
  - Puerto Rico (PR)
  - United States Minor Outlying Islands (UM)
- Moved 'Virgin Islands' (VI) to be grouped with other territories
- Modified the US_STATES export to sort entries alphabetically by state name rather than by code

Testing
======
<!---
How did you test your changes? How might someone else test them?
--->

The changes can be tested by verifying that any UI components using the US_STATES list display all states and territories in alphabetical order, and that the newly added territories appear in the list.

Checklist
======

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.