### PR TITLE
feat: add visibility toggle for SSN and Member ID inputs; enhance SSN formatting

### DIFF
--- a/src/components/form/MemberIdInput.tsx
+++ b/src/components/form/MemberIdInput.tsx
@@ -1,5 +1,12 @@
-import { useRef, type ReactNode } from 'react';
-import { Box, TextField, type TextFieldProps } from '@mui/material';
+import { useRef, useState, type ReactNode } from 'react';
+import {
+  Box,
+  IconButton,
+  InputAdornment,
+  TextField,
+  type TextFieldProps,
+} from '@mui/material';
+import { Visibility, VisibilityOff } from '@mui/icons-material';
 
 export type MemberIdInputProps = Omit<TextFieldProps, 'onChange'> & {
   onChange?: (event: { target: { value: string } }) => void;
@@ -43,13 +50,16 @@ export function MemberIdInput({
   // Cursor position captured in onKeyDown, used to reconstruct raw on insert/overwrite.
   const cursorRef = useRef<number>(0);
 
+  const [isVisible, setIsVisible] = useState(false);
+
   const rawValue = value ?? '';
   const isRedacted = isRedactedValue(rawValue);
+  const canToggleVisibility = !isRedacted && rawValue.length > 0;
   // "Actively typing" = the user set this value themselves (not loaded from outside).
   // Empty is always active so the field accepts fresh input naturally.
   const isActivelyTyping =
     !isRedacted && (rawValue === '' || lastPropagatedRef.current === rawValue);
-  const displayValue = buildDisplayValue(rawValue);
+  const displayValue = isVisible ? rawValue : buildDisplayValue(rawValue);
 
   function propagate(newRaw: string) {
     lastPropagatedRef.current = newRaw;
@@ -64,6 +74,12 @@ export function MemberIdInput({
         value={displayValue}
         placeholder={placeholder}
         onChange={(e) => {
+          // When visible, pass through directly — no masking logic needed.
+          if (isVisible) {
+            propagate(e.target.value);
+            return;
+          }
+
           const newDisplay = e.target.value;
           const prevRaw = lastPropagatedRef.current ?? '';
           const prevDisplay = buildDisplayValue(prevRaw);
@@ -106,6 +122,15 @@ export function MemberIdInput({
           onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
             cursorRef.current = e.currentTarget.selectionStart ?? 0;
 
+            // When visible, only handle backspace/delete for clear-all behavior.
+            if (isVisible) {
+              if (e.key === 'Backspace' || e.key === 'Delete') {
+                e.preventDefault();
+                if (rawValue !== '') propagate('');
+              }
+              return;
+            }
+
             // Backspace/Delete always clears the entire field.
             if (e.key === 'Backspace' || e.key === 'Delete') {
               e.preventDefault();
@@ -124,7 +149,28 @@ export function MemberIdInput({
         }}
         InputProps={{
           ...InputProps,
-          endAdornment: InputProps?.endAdornment,
+          endAdornment: (
+            <>
+              {canToggleVisibility && (
+                <InputAdornment position='end'>
+                  <IconButton
+                    aria-label={isVisible ? 'hide member id' : 'show member id'}
+                    edge='end'
+                    size='small'
+                    onClick={() => setIsVisible((prev) => !prev)}
+                    tabIndex={-1}
+                  >
+                    {isVisible ? (
+                      <VisibilityOff fontSize='small' />
+                    ) : (
+                      <Visibility fontSize='small' />
+                    )}
+                  </IconButton>
+                </InputAdornment>
+              )}
+              {InputProps?.endAdornment}
+            </>
+          ),
         }}
         fullWidth
       />

--- a/src/components/form/NewOneClickForm/core/formats/ssn.format.ts
+++ b/src/components/form/NewOneClickForm/core/formats/ssn.format.ts
@@ -1,3 +1,5 @@
 export const ssnFormat = (value: string) => {
-  return value.replace(/(\d{3})-?(\d{2})-?(\d{4})/, '•••-••-$3');
+  // Normalize asterisk-redacted values (***-**-6789) to bullet format
+  const normalized = value.replace(/\*/g, '•');
+  return normalized.replace(/(\d{3})-?(\d{2})-?(\d{4})/, '•••-••-$3');
 };

--- a/src/components/form/NewOneClickForm/core/validations/other/ssn.schema.ts
+++ b/src/components/form/NewOneClickForm/core/validations/other/ssn.schema.ts
@@ -3,9 +3,10 @@ import { ssnRegex } from '../../../../../../utils/ssn';
 
 /**
  * Validation schema for SSN field in forms
- * Supports both masked (•••-••-1234) and unmasked (123456789) formats
+ * Supports both masked (•••-••-1234 or ***-**-1234) and unmasked (123456789) formats
  */
 export const ssnSchema = z.string().refine((value) => {
   if (/^•••-••-\d{4}$/.test(value)) return true;
+  if (/^\*\*\*-\*\*-\d{4}$/.test(value)) return true;
   return ssnRegex.test(value);
 }, 'Invalid SSN');

--- a/src/components/form/SSNInput.tsx
+++ b/src/components/form/SSNInput.tsx
@@ -1,5 +1,12 @@
-import { ReactNode } from 'react';
-import { Box, TextField, type TextFieldProps } from '@mui/material';
+import { ReactNode, useState } from 'react';
+import {
+  Box,
+  IconButton,
+  InputAdornment,
+  TextField,
+  type TextFieldProps,
+} from '@mui/material';
+import { Visibility, VisibilityOff } from '@mui/icons-material';
 
 import { DataFieldClearAdornment } from './DataFieldClearAdornment';
 import { ChangeEvent, TextMaskCustom } from './TextMaskCustom';
@@ -18,6 +25,15 @@ export type SSNInputProps = TextFieldProps & {
   shouldHaveCloseAdornment?: boolean;
 };
 
+function isRedactedValue(value: string): boolean {
+  return value.includes('*') || value.includes('•');
+}
+
+// Normalize * → • so that imask accepts the redacted characters.
+function normalizeRedactedValue(value: string): string {
+  return value.replace(/\*/g, '•');
+}
+
 /**
  * This component manages the input of type SSN.
  * @constructor
@@ -27,11 +43,21 @@ export function SSNInput({
   label = 'Social Security number',
   value,
   shouldHaveCloseAdornment = false,
-  mask = 'XXX-XX-0000',
+  mask: maskProp = 'XXX-XX-0000',
   placeholder = '___-__-____',
   InputProps,
   ...rest
 }: SSNInputProps) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const rawValue = value ?? '';
+  const isRedacted = isRedactedValue(rawValue);
+  const canToggleVisibility = !isRedacted && rawValue.replace(/-/g, '').length > 0;
+  // Normalize * → • so imask accepts redacted characters via the X definition.
+  const normalizedValue = normalizeRedactedValue(rawValue);
+
+  const activeMask = isVisible ? '000-00-0000' : maskProp;
+
   const handleChange = (value: string): void => {
     onChange?.({ target: { value } });
   };
@@ -44,10 +70,10 @@ export function SSNInput({
   const textFieldStyle: TextStyles = {
     ...rest,
     label,
-    value: value?.replace(/-/g, '') ?? '',
+    value: normalizedValue.replace(/-/g, ''),
     onChange: ((e, nativeEvent) => {
       if (!nativeEvent) return;
-      const currentValue = value?.replace(/-/g, '') ?? '';
+      const currentValue = normalizedValue.replace(/-/g, '');
       const newValue = e.target.value.replace(/-/g, '');
       // If the user is removing characters, clear the field
       if (newValue.length < currentValue.length) {
@@ -65,7 +91,7 @@ export function SSNInput({
       // Make placeholder always visible
       lazy: true,
       // Mask in the pattern of SSN.
-      mask,
+      mask: activeMask,
       definitions: {
         X: {
           mask: /[0-9•]/,
@@ -85,6 +111,23 @@ export function SSNInput({
       inputComponent: TextMaskCustom as any,
       endAdornment: (
         <>
+          {canToggleVisibility && (
+            <InputAdornment position='end'>
+              <IconButton
+                aria-label={isVisible ? 'hide ssn' : 'show ssn'}
+                edge='end'
+                size='small'
+                onClick={() => setIsVisible((prev) => !prev)}
+                tabIndex={-1}
+              >
+                {isVisible ? (
+                  <VisibilityOff fontSize='small' />
+                ) : (
+                  <Visibility fontSize='small' />
+                )}
+              </IconButton>
+            </InputAdornment>
+          )}
           {!!shouldHaveCloseAdornment && (
             <DataFieldClearAdornment
               onClick={handleClear}

--- a/src/components/form/SSNInput.tsx
+++ b/src/components/form/SSNInput.tsx
@@ -52,7 +52,8 @@ export function SSNInput({
 
   const rawValue = value ?? '';
   const isRedacted = isRedactedValue(rawValue);
-  const canToggleVisibility = !isRedacted && rawValue.replace(/-/g, '').length > 0;
+  const canToggleVisibility =
+    !isRedacted && rawValue.replace(/-/g, '').length > 0;
   // Normalize * → • so imask accepts redacted characters via the X definition.
   const normalizedValue = normalizeRedactedValue(rawValue);
 

--- a/src/stories/components/form/CredentialForm.stories.tsx
+++ b/src/stories/components/form/CredentialForm.stories.tsx
@@ -472,7 +472,7 @@ const mockCredentials = [
     uuid: '99fb267d-c1d0-4b12-a296-5533317dc5c2',
     type: 'ssn',
     value: {
-      ssn: '000456789',
+      ssn: '•••-••-6789',
     },
   },
   {


### PR DESCRIPTION
## Summary

Add visibility toggle (show/hide) buttons to SSN and Member ID inputs, and improve handling of redacted SSN values that use asterisk (`*`) masking.

## Changes

- **SSNInput**: Added eye icon toggle to reveal/hide the raw SSN value. When visible, switches the imask pattern to `000-00-0000` to display plain digits. Normalizes asterisk-redacted values (`***-**-6789`) to bullet format (`•••-••-6789`) for consistent masking.
- **MemberIdInput**: Added eye icon toggle to reveal/hide the raw Member ID value. When visible, displays the raw value and bypasses masking logic on input. Backspace/Delete still clears the entire field in both modes.
- **SSN validation schema**: Accepts asterisk-redacted format (`***-**-1234`) in addition to the existing bullet-redacted format.
- **SSN format utility**: Normalizes asterisk-redacted values to bullet format before applying the display mask.
- **Storybook**: Updated mock SSN credential to use the pre-formatted redacted format (`•••-••-6789`) instead of raw digits.

## Testing

- Verify SSN and Member ID inputs render the visibility toggle icon only when the field has a non-redacted value.
- Click the eye icon to confirm the raw value is shown; click again to confirm it re-masks.
- Enter a new SSN/Member ID and confirm the toggle appears and functions correctly.
- Confirm backspace/delete still clears the entire field in both visible and hidden modes.
- Test with asterisk-redacted SSN values (e.g., `***-**-6789`) to confirm they normalize and display correctly.
- Run `npm run test` to verify existing tests pass.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
