### PR TITLE
enhancement/add-timezone-react-datepicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@verifiedinc-public/shared-ui-elements",
       "version": "9.6.0",
       "dependencies": {
+        "date-fns-tz": "^3.2.0",
         "react-datepicker": "^7.6.0"
       },
       "devDependencies": {
@@ -5723,6 +5724,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/de-indent": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "publish:prerelease": "npm version prerelease --preid=beta && npm publish --tag beta"
   },
   "dependencies": {
+    "date-fns-tz": "^3.2.0",
     "react-datepicker": "^7.6.0"
   },
   "devDependencies": {
@@ -120,7 +121,6 @@
   },
   "peerDependencies": {
     "@date-fns/tz": "^1.2.0",
-    "date-fns": ">=3.6.0",
     "@dotlottie/react-player": "^1.6.19",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
@@ -132,6 +132,7 @@
     "@mui/material": ">=5 <6",
     "@tanstack/react-query": ">=5",
     "@tanstack/react-virtual": ">=3",
+    "date-fns": ">=3.6.0",
     "decimal.js": ">=10.4.3",
     "framer-motion": ">=11.11.1",
     "html-to-image": ">=1.11.13 <2",

--- a/src/components/form/DateRangeInput/index.tsx
+++ b/src/components/form/DateRangeInput/index.tsx
@@ -7,10 +7,13 @@ import {
 } from 'react';
 import { Box, TextField } from '@mui/material';
 import DatePicker from 'react-datepicker';
+import { formatInTimeZone, fromZonedTime, toZonedTime } from 'date-fns-tz';
 
 import { reactDatepickerCss as pickerCSS } from '../../../styles/lib/react-datepicker';
 
 import { useOnClickOutside } from '../../../hooks';
+
+import { ISO_TZ_FORMAT } from '../../../constants/date';
 
 import { useStyle } from './style';
 
@@ -36,6 +39,10 @@ interface DateRangeInputProps {
   startDate?: Date | number;
   endDate?: Date | number;
   onChange: (startDate: number, endDate: number) => void;
+  /** Optional: called with ISO strings formatted in the given timeZone */
+  onChangeTz?: (startDate: string, endDate: string) => void;
+  /** IANA time zone name (e.g. "America/New_York"). Omit for local time behavior. */
+  timeZone?: string;
 }
 
 export const DateRangeInput: FC<DateRangeInputProps> = (
@@ -80,7 +87,10 @@ export const DateRangeInput: FC<DateRangeInputProps> = (
         // Set the minimum date to the 2023
         minDate={new Date(2023, 0, 1)}
         // Set the maximum date to the current date
-        maxDate={new Date()}
+        // Set the maximum date to the current date based on the target timezone
+        maxDate={
+          props.timeZone ? toZonedTime(new Date(), props.timeZone) : new Date()
+        }
         onChange={([start, end], event) => {
           // Update local state to allow to change the date range
           setDateRange([start, end]);
@@ -97,6 +107,17 @@ export const DateRangeInput: FC<DateRangeInputProps> = (
 
           // Pass UTC timestamps to onChange handler
           props.onChange(+start, +end);
+
+          if (props.timeZone && props.onChangeTz) {
+            // Treat the selected wall-clock values as being in the target timezone
+            const startUtc = fromZonedTime(start, props.timeZone);
+            const endUtc = fromZonedTime(end, props.timeZone);
+
+            props.onChangeTz(
+              formatInTimeZone(startUtc, props.timeZone, ISO_TZ_FORMAT),
+              formatInTimeZone(endUtc, props.timeZone, ISO_TZ_FORMAT),
+            );
+          }
         }}
         customInput={<Input />}
       />

--- a/src/constants/date.ts
+++ b/src/constants/date.ts
@@ -1,0 +1,1 @@
+export const ISO_TZ_FORMAT = "yyyy-MM-dd'T'HH:mm:ssxxx";

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,2 +1,3 @@
+export * from './date';
 export * from './email';
 export * from './metrics';

--- a/src/contexts/metrics/Metrics.context.tsx
+++ b/src/contexts/metrics/Metrics.context.tsx
@@ -6,6 +6,9 @@ import {
   useMemo,
 } from 'react';
 import cloneDeep from 'lodash/cloneDeep';
+import { formatInTimeZone, fromZonedTime, toZonedTime } from 'date-fns-tz';
+
+import { ISO_TZ_FORMAT } from '../../constants/date';
 
 import {
   MetricsInterval,
@@ -175,9 +178,33 @@ export function MetricsProvider(props: MetricsContextProps) {
 
   const setTimezone = useCallback(
     (timezone: string) => {
-      dispatch({ timezone });
+      const updates: Partial<InternalMetricsReducer> = { timezone };
+
+      if (state.zonedStartDate && state.zonedEndDate) {
+        const startWallClock = toZonedTime(
+          new Date(state.zonedStartDate),
+          state.timezone,
+        );
+        const endWallClock = toZonedTime(
+          new Date(state.zonedEndDate),
+          state.timezone,
+        );
+
+        updates.zonedStartDate = formatInTimeZone(
+          fromZonedTime(startWallClock, timezone),
+          timezone,
+          ISO_TZ_FORMAT,
+        );
+        updates.zonedEndDate = formatInTimeZone(
+          fromZonedTime(endWallClock, timezone),
+          timezone,
+          ISO_TZ_FORMAT,
+        );
+      }
+
+      dispatch(updates);
     },
-    [dispatch],
+    [dispatch, state.zonedStartDate, state.zonedEndDate, state.timezone],
   );
 
   const setZonedDateRange = useCallback(

--- a/src/contexts/metrics/Metrics.context.tsx
+++ b/src/contexts/metrics/Metrics.context.tsx
@@ -22,6 +22,8 @@ export type InternalMetricsReducer = {
   timezone: string;
   startDate: number; //  timestamp Date
   endDate: number; //  timestamp Date
+  zonedStartDate: string | null;
+  zonedEndDate: string | null;
 };
 
 export type MetricsReducer = {
@@ -32,12 +34,15 @@ export type MetricsReducer = {
   timezone: string;
   startDate: number; //  timestamp Date
   endDate: number; //  timestamp Date
+  zonedStartDate: string | null;
+  zonedEndDate: string | null;
 };
 
 type MetricsContext = {
   filter: MetricsReducer & {
     setInterval: (interval: MetricsIntervalType) => void;
     setDateRange: (startDate: number, endDate: number) => void;
+    setZonedDateRange: (zonedStartDate: string, zonedEndDate: string) => void;
     setBrands: (brands: BrandFilter[]) => void;
     setBrand: (brands: BrandFilter | undefined) => void;
     setMonthlyBillableBrands: (brands: BrandFilter[]) => void;
@@ -104,6 +109,8 @@ export function MetricsProvider(props: MetricsContextProps) {
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       startDate: +startDate,
       endDate: +endDate,
+      zonedStartDate: null,
+      zonedEndDate: null,
     },
   );
 
@@ -173,6 +180,13 @@ export function MetricsProvider(props: MetricsContextProps) {
     [dispatch],
   );
 
+  const setZonedDateRange = useCallback(
+    (zonedStartDate: string, zonedEndDate: string) => {
+      dispatch({ zonedStartDate, zonedEndDate });
+    },
+    [dispatch],
+  );
+
   const stateMemo = useMemo(() => {
     if (!state) return state;
     return {
@@ -190,6 +204,7 @@ export function MetricsProvider(props: MetricsContextProps) {
         ...stateMemo,
         setInterval,
         setDateRange,
+        setZonedDateRange,
         setBrands,
         setBrand,
         setMonthlyBillableBrands,
@@ -200,6 +215,7 @@ export function MetricsProvider(props: MetricsContextProps) {
       stateMemo,
       setInterval,
       setDateRange,
+      setZonedDateRange,
       setBrands,
       setBrand,
       setMonthlyBillableBrands,

--- a/src/hooks/usePersistedReducer.ts
+++ b/src/hooks/usePersistedReducer.ts
@@ -25,7 +25,7 @@ export function usePersistedReducer<R extends Reducer<any, any>, I>(
 
     if (persisted) {
       try {
-        return persisted;
+        return { ...initialState, ...persisted };
       } catch {
         return initialState;
       }

--- a/src/styles/lib/react-datepicker.ts
+++ b/src/styles/lib/react-datepicker.ts
@@ -955,4 +955,9 @@ select.react-datepicker__year-select {
 .react-datepicker__day:not([aria-disabled='true']):hover {
   color: #fff;
 }
+
+.react-datepicker__month-read-view:hover .react-datepicker__month-read-view--down-arrow,
+.react-datepicker__year-read-view:hover .react-datepicker__year-read-view--down-arrow {
+  border-top-color: #008a01;
+}
 `;


### PR DESCRIPTION
## Summary

Add timezone-aware date handling to the shared UI library's `DateRangeInput` component and `MetricsProvider` context, enabling consumers to work with dates in a specific IANA time zone instead of only local time.

## Changes

- Added `date-fns-tz` as a dependency for timezone conversion and formatting utilities
- Added `ISO_TZ_FORMAT` constant (`yyyy-MM-dd'T'HH:mm:ssxxx`) for consistent timezone-aware date formatting
- Extended `DateRangeInput` with optional `timeZone` and `onChangeTz` props — when provided, the component converts selected wall-clock dates to the target timezone and emits ISO strings via `onChangeTz`; `maxDate` is also adjusted to the target timezone
- Added `zonedStartDate` / `zonedEndDate` fields and `setZonedDateRange` action to the Metrics context and provider
- Updated `setTimezone` in `MetricsProvider` to re-project existing zoned dates into the new timezone when the timezone changes
- Fixed `usePersistedReducer` to merge persisted state with `initialState` so that newly added fields (e.g. `zonedStartDate`) get their defaults even when restoring from stale persisted data
- Added hover style for month/year dropdown arrows in the react-datepicker stylesheet
- Moved `date-fns` from `dependencies` to `peerDependencies` (it was already expected as a peer)

## Testing

- Verify `DateRangeInput` works without `timeZone` prop (existing behavior unchanged)
- Verify `DateRangeInput` with `timeZone="America/New_York"` — selecting a date range should call `onChangeTz` with ISO strings offset to the Eastern timezone
- Verify `maxDate` respects the target timezone (e.g., if it's still April 10 in Pacific time but already April 11 in Tokyo, `maxDate` should reflect the target zone)
- Verify `MetricsProvider`: changing the timezone via `setTimezone` re-projects `zonedStartDate`/`zonedEndDate` into the new timezone while preserving the wall-clock values
- Verify persisted reducer correctly merges new default fields when restoring from localStorage that doesn't contain `zonedStartDate`/`zonedEndDate`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
