### PR TITLE
feat/customer-facing-logs-health-tts

### DIFF
--- a/src/components/logs/LogsTable/LogDetailPanel.tsx
+++ b/src/components/logs/LogsTable/LogDetailPanel.tsx
@@ -1,6 +1,7 @@
 import { Box, Paper, Stack, Typography } from '@mui/material';
 
 import type { LogEntry } from '../types';
+import { PRODUCT_LABELS } from '../constants';
 
 interface LogDetailPanelProps {
   log: LogEntry;
@@ -56,6 +57,7 @@ export function LogDetailPanel({ log }: LogDetailPanelProps) {
             <DetailField label='Session UUID' value={log.sessionUuid} />
           )}
           <DetailField label='Source' value={log.source} />
+          <DetailField label='Product' value={PRODUCT_LABELS[log.product]} />
           <DetailField
             label='Event Type'
             value={log.errorCode ? 'response_error' : 'request'}

--- a/src/components/logs/LogsTable/LogsTable.tsx
+++ b/src/components/logs/LogsTable/LogsTable.tsx
@@ -469,7 +469,8 @@ export function LogsTable({
                         variant='outlined'
                         sx={{
                           fontSize: 13,
-                          fontFamily: 'monospace',
+                          fontWeight: 600,
+                          minWidth: 110,
                         }}
                       />
                     </TableCell>

--- a/src/components/logs/LogsTable/LogsTable.tsx
+++ b/src/components/logs/LogsTable/LogsTable.tsx
@@ -454,13 +454,12 @@ export function LogsTable({
                         size='small'
                         variant='filled'
                         sx={{
-                          fontWeight: 500,
+                          fontWeight: 600,
                           fontSize: 12,
                           minWidth: 40,
                           bgcolor:
                             row.source === 'sdk' ? '#4FC3F7' : 'primary.main',
                           color: 'white',
-                          fontFamily: 'monospace',
                         }}
                       />
                     </TableCell>

--- a/src/components/logs/LogsTable/LogsTable.tsx
+++ b/src/components/logs/LogsTable/LogsTable.tsx
@@ -142,6 +142,34 @@ function OverflowTooltip({ text }: { text: string }) {
   );
 }
 
+function OverflowChip({
+  label,
+  ...chipProps
+}: { label: string } & Omit<React.ComponentProps<typeof Chip>, 'label'>) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [overflow, setOverflow] = useState(false);
+
+  useEffect(() => {
+    const labelEl = ref.current?.querySelector('.MuiChip-label');
+    if (labelEl) setOverflow(labelEl.scrollWidth > labelEl.clientWidth);
+  }, [label]);
+
+  return (
+    <Tooltip title={overflow ? label : ''} placement='top'>
+      <Chip
+        ref={ref}
+        label={label}
+        {...chipProps}
+        sx={{
+          ...chipProps.sx,
+          maxWidth: '100%',
+          '& .MuiChip-label': { overflow: 'hidden', textOverflow: 'ellipsis' },
+        }}
+      />
+    </Tooltip>
+  );
+}
+
 const ROW_HEIGHT_ESTIMATE = 48;
 
 const MONO_SX = { fontFamily: 'monospace' } as const;
@@ -426,23 +454,25 @@ export function LogsTable({
                         size='small'
                         variant='filled'
                         sx={{
-                          fontWeight: 600,
+                          fontWeight: 500,
                           fontSize: 12,
                           minWidth: 40,
                           bgcolor:
                             row.source === 'sdk' ? '#4FC3F7' : 'primary.main',
                           color: 'white',
+                          fontFamily: 'monospace',
                         }}
                       />
                     </TableCell>
                     <TableCell>
-                      <Typography
-                        variant='body2'
-                        color='text.primary'
-                        sx={{ ...monoSx, fontWeight: 500 }}
-                      >
-                        {PRODUCT_LABELS[row.product]}
-                      </Typography>
+                      <OverflowChip
+                        label={PRODUCT_LABELS[row.product]}
+                        variant='outlined'
+                        sx={{
+                          fontSize: 13,
+                          fontFamily: 'monospace',
+                        }}
+                      />
                     </TableCell>
                     <TableCell>
                       <OverflowTooltip text={formatEvent(row)} />

--- a/src/components/logs/LogsTable/LogsTable.tsx
+++ b/src/components/logs/LogsTable/LogsTable.tsx
@@ -25,6 +25,7 @@ import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
 import { useSnackbar } from '../../Snackbar';
 import { formatLogTimestamp } from '../../../utils/date';
 import type { LogEntry, LogsResponse } from '../types';
+import { PRODUCT_LABELS } from '../constants';
 import { LogDetailPanel } from './LogDetailPanel';
 import { useBidirectionalScroll } from '../../../hooks/useBidirectionalScroll';
 
@@ -167,6 +168,7 @@ export function LogsTable({
       { label: 'Phone', width: 150 },
       { label: '1-Click UUID', width: 130 },
       { label: 'Source', width: 90 },
+      { label: 'Product', width: 140 },
       { label: 'Event', width: isLgAndBelow ? 125 : 200 },
       { label: 'HTTP', align: 'right' as const, width: 75 },
       { label: 'Latency', align: 'right' as const, width: 100 },
@@ -277,7 +279,7 @@ export function LogsTable({
           <TableBody>
             {isLoading && rows.length === 0 && (
               <TableRow>
-                <TableCell colSpan={9} sx={{ textAlign: 'center', py: 2 }}>
+                <TableCell colSpan={10} sx={{ textAlign: 'center', py: 2 }}>
                   <Typography color='text.secondary'>Loading...</Typography>
                 </TableCell>
               </TableRow>
@@ -293,7 +295,7 @@ export function LogsTable({
                 }}
               >
                 <TableCell
-                  colSpan={9}
+                  colSpan={10}
                   sx={{
                     textAlign: 'center',
                     py: 0.75,
@@ -434,6 +436,15 @@ export function LogsTable({
                       />
                     </TableCell>
                     <TableCell>
+                      <Typography
+                        variant='body2'
+                        color='text.primary'
+                        sx={{ ...monoSx, fontWeight: 500 }}
+                      >
+                        {PRODUCT_LABELS[row.product]}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
                       <OverflowTooltip text={formatEvent(row)} />
                     </TableCell>
                     <TableCell sx={{ textAlign: 'right' }}>
@@ -485,7 +496,7 @@ export function LogsTable({
                   {isExpanded && (
                     <TableRow>
                       <TableCell
-                        colSpan={9}
+                        colSpan={10}
                         sx={{
                           py: 0,
                           px: 1,
@@ -519,7 +530,7 @@ export function LogsTable({
                 }}
               >
                 <TableCell
-                  colSpan={9}
+                  colSpan={10}
                   sx={{
                     textAlign: 'center',
                     py: 0.75,

--- a/src/components/logs/constants.ts
+++ b/src/components/logs/constants.ts
@@ -1,0 +1,8 @@
+import type { LogEntry } from './types';
+
+export const PRODUCT_LABELS: Record<LogEntry['product'], string> = {
+  signup: '1-Click Signup',
+  verify: '1-Click Verify',
+  health: '1-Click Health',
+  'text-to-signup': 'Text to Signup',
+};

--- a/src/components/logs/types.ts
+++ b/src/components/logs/types.ts
@@ -2,7 +2,7 @@ export interface LogEntry {
   brandUuid: string;
   phone: string | null;
   uuid: string | null;
-  product: 'signup' | 'verify';
+  product: 'signup' | 'verify' | 'health' | 'text-to-signup';
   sessionUuid: string | null;
   method: string;
   path: string;


### PR DESCRIPTION
## Summary
Adds a Product column to the customer-facing LogsTable (with matching detail panel field) and extends the `LogEntry` product union to cover all four 1-Click products.

## Changes
- Add `PRODUCT_LABELS` map in `src/components/logs/constants.ts` for display strings.
- Extend `LogEntry.product` union with `health` and `text-to-signup`.
- Add Product column to `LogsTable` with new `OverflowChip` component (ellipsis + tooltip on overflow); update `colSpan` from 9 to 10 across loading/empty/expanded rows.
- Show Product field in `LogDetailPanel`.

## Testing
- Run Storybook / consuming client; verify Product column renders correct label for each product and chip tooltip appears when label truncates.
- Expand a row and confirm Product shows in detail panel.
- Verify loading, empty, and end-of-list states still span the full table width.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
