### PR TITLE
enhancement/remove-factory-timezone

### DIFF
--- a/src/components/form/TimezoneInput/timezones.ts
+++ b/src/components/form/TimezoneInput/timezones.ts
@@ -272,7 +272,6 @@ const timezones = [
   { name: 'Atlantic/Azores', utc_offset: '00:00:00' },
   { name: 'Atlantic/St_Helena', utc_offset: '00:00:00' },
   { name: 'Atlantic/Reykjavik', utc_offset: '00:00:00' },
-  { name: 'Factory', utc_offset: '00:00:00' },
   { name: 'Iceland', utc_offset: '00:00:00' },
   { name: 'Eire', utc_offset: '01:00:00' },
   { name: 'Africa/Casablanca', utc_offset: '01:00:00' },


### PR DESCRIPTION
## Summary
Remove `Factory` entry from the `TimezoneInput` timezone list. It is an IANA internal placeholder, not a user-selectable zone.

## Changes
- Drop `{ name: 'Factory', utc_offset: '00:00:00' }` from `src/components/form/TimezoneInput/timezones.ts`.

## Testing
- Render `TimezoneInput` in Storybook; confirm `Factory` no longer appears in the dropdown and other zones still load/sort correctly.
- Run `npm run lint` and `npm run test`.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
