### PR TITLE
feat: enhance charts and billable events table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "9.9.2-beta.0",
+  "version": "9.9.2-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@verifiedinc-public/shared-ui-elements",
-      "version": "9.9.2-beta.0",
+      "version": "9.9.2-beta.1",
       "dependencies": {
         "date-fns-tz": "^3.2.0",
         "react-datepicker": "^7.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "9.9.2-beta.1",
+  "version": "9.9.2-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@verifiedinc-public/shared-ui-elements",
-      "version": "9.9.2-beta.1",
+      "version": "9.9.2-beta.2",
       "dependencies": {
         "date-fns-tz": "^3.2.0",
         "react-datepicker": "^7.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "9.9.2-beta.2",
+  "version": "9.9.2-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@verifiedinc-public/shared-ui-elements",
-      "version": "9.9.2-beta.2",
+      "version": "9.9.2-beta.3",
       "dependencies": {
         "date-fns-tz": "^3.2.0",
         "react-datepicker": "^7.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "9.9.2-beta.3",
+  "version": "9.9.2-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@verifiedinc-public/shared-ui-elements",
-      "version": "9.9.2-beta.3",
+      "version": "9.9.2-beta.4",
       "dependencies": {
         "date-fns-tz": "^3.2.0",
         "react-datepicker": "^7.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "9.9.1",
+  "version": "9.9.2-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@verifiedinc-public/shared-ui-elements",
-      "version": "9.9.1",
+      "version": "9.9.2-beta.0",
       "dependencies": {
         "date-fns-tz": "^3.2.0",
         "react-datepicker": "^7.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "9.9.2-beta.0",
+  "version": "9.9.2-beta.1",
   "description": "A set of UI components, utilities that is shareable with the core apps.",
   "private": false,
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "9.9.1",
+  "version": "9.9.2-beta.0",
   "description": "A set of UI components, utilities that is shareable with the core apps.",
   "private": false,
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "9.9.2-beta.1",
+  "version": "9.9.2-beta.2",
   "description": "A set of UI components, utilities that is shareable with the core apps.",
   "private": false,
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "9.9.2-beta.2",
+  "version": "9.9.2-beta.3",
   "description": "A set of UI components, utilities that is shareable with the core apps.",
   "private": false,
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "9.9.2-beta.3",
+  "version": "9.9.2-beta.4",
   "description": "A set of UI components, utilities that is shareable with the core apps.",
   "private": false,
   "sideEffects": false,

--- a/src/components/CopyableUuid/index.tsx
+++ b/src/components/CopyableUuid/index.tsx
@@ -153,9 +153,11 @@ export function CopyableUuid({
         size='small'
         aria-label={`Copy ${label}`}
         onClick={handleCopy}
-        sx={[{ p: 0.25, ml: 0.5 }, iconSx as any].filter(Boolean)}
+        sx={[{ p: 0.25, ml: 0.5, fontSize: 'inherit' }, iconSx as any].filter(
+          Boolean,
+        )}
       >
-        <ContentCopy sx={{ fontSize: 13 }} />
+        <ContentCopy fontSize='inherit' />
       </IconButton>
     </Stack>
   );

--- a/src/components/CopyableUuid/index.tsx
+++ b/src/components/CopyableUuid/index.tsx
@@ -96,12 +96,27 @@ export function CopyableUuid({
 
   if (variant === 'text') {
     const textSx = {
+      // Reset native <button> styles so it reads as plain text.
+      background: 'transparent',
+      border: 0,
+      padding: 0,
+      margin: 0,
+      font: 'inherit',
+      color: 'inherit',
+      textAlign: 'inherit',
       cursor: 'pointer',
       '&:hover': { textDecoration: 'underline' },
+      '&:focus-visible': {
+        outline: '2px solid currentColor',
+        outlineOffset: 2,
+      },
     };
     return (
       <Typography
+        component='button'
+        type='button'
         variant='body2'
+        aria-label={`Copy ${label}`}
         onClick={handleCopy}
         {...restTypographyProps}
         sx={

--- a/src/components/CopyableUuid/index.tsx
+++ b/src/components/CopyableUuid/index.tsx
@@ -35,6 +35,8 @@ export interface CopyableUuidProps {
   /** Whether to use monospace typography. Defaults to true. */
   mono?: boolean;
   typographyProps?: Omit<TypographyProps, 'children'>;
+  /** Styles applied to the copy icon button (button variant only). */
+  iconSx?: SxProps;
   sx?: SxProps;
 }
 
@@ -59,6 +61,7 @@ export function CopyableUuid({
   placeholder = '—',
   mono = true,
   typographyProps,
+  iconSx,
   sx,
 }: Readonly<CopyableUuidProps>): React.ReactElement {
   const { copy } = useCopyToClipboard({ type: 'text/plain' });
@@ -73,7 +76,7 @@ export function CopyableUuid({
         variant='body2'
         color='text.secondary'
         {...restTypographyProps}
-        sx={[monoSx, typographySx as any, sx as any].filter(Boolean) as any}
+        sx={[monoSx, typographySx as any, sx].filter(Boolean)}
       >
         {placeholder}
       </Typography>
@@ -120,9 +123,9 @@ export function CopyableUuid({
         onClick={handleCopy}
         {...restTypographyProps}
         sx={
-          [monoSx, textSx, typographySx as any, sx as any].filter(
+          [monoSx, textSx, typographySx as any, sx].filter(
             Boolean,
-          ) as any
+          )
         }
       >
         {truncated}
@@ -145,7 +148,7 @@ export function CopyableUuid({
         color='text.secondary'
         noWrap
         {...restTypographyProps}
-        sx={[monoSx, typographySx as any].filter(Boolean) as any}
+        sx={[monoSx, typographySx as any].filter(Boolean)}
       >
         {truncated}
       </Typography>
@@ -154,7 +157,7 @@ export function CopyableUuid({
         size='small'
         aria-label={`Copy ${label}`}
         onClick={handleCopy}
-        sx={{ p: 0.25, ml: 0.5 }}
+        sx={[{ p: 0.25, ml: 0.5 }, iconSx as any].filter(Boolean)}
       >
         <ContentCopy sx={{ fontSize: 13 }} />
       </IconButton>

--- a/src/components/CopyableUuid/index.tsx
+++ b/src/components/CopyableUuid/index.tsx
@@ -122,11 +122,7 @@ export function CopyableUuid({
         aria-label={`Copy ${label}`}
         onClick={handleCopy}
         {...restTypographyProps}
-        sx={
-          [monoSx, textSx, typographySx as any, sx].filter(
-            Boolean,
-          )
-        }
+        sx={[monoSx, textSx, typographySx as any, sx].filter(Boolean)}
       >
         {truncated}
       </Typography>

--- a/src/components/CopyableUuid/index.tsx
+++ b/src/components/CopyableUuid/index.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { ContentCopy } from '@mui/icons-material';
+import {
+  IconButton,
+  Stack,
+  Typography,
+  type SxProps,
+  type TypographyProps,
+} from '@mui/material';
+
+import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
+import { useSnackbar } from '../Snackbar';
+
+export type CopyableUuidVariant = 'text' | 'button';
+
+export interface CopyableUuidProps {
+  uuid: string | null | undefined;
+  /** Snackbar label. Defaults to "UUID". */
+  label?: string;
+  /** Number of leading characters to keep when truncating. Defaults to 4. */
+  head?: number;
+  /**
+   * Number of trailing characters to keep when truncating. Defaults to 4.
+   * When 0, renders a head-only ellipsis ("abcd...").
+   */
+  tail?: number;
+  /**
+   * `text` — clickable monospace text that copies on click (inline legend style).
+   * `button` — text followed by a hover-revealed copy icon (table cell style).
+   * Defaults to `button`.
+   */
+  variant?: CopyableUuidVariant;
+  /** Fallback rendered when `uuid` is nullish/empty. Defaults to `—`. */
+  placeholder?: React.ReactNode;
+  /** Whether to use monospace typography. Defaults to true. */
+  mono?: boolean;
+  typographyProps?: Omit<TypographyProps, 'children'>;
+  sx?: SxProps;
+}
+
+function truncate(uuid: string, head: number, tail: number): string {
+  if (tail === 0) {
+    return uuid.length <= head ? uuid : `${uuid.slice(0, head)}...`;
+  }
+
+  if (uuid.length <= head + tail + 1) {
+    return uuid;
+  }
+
+  return `${uuid.slice(0, head)}…${uuid.slice(-tail)}`;
+}
+
+export function CopyableUuid({
+  uuid,
+  label = 'UUID',
+  head = 4,
+  tail = 4,
+  variant = 'button',
+  placeholder = '—',
+  mono = true,
+  typographyProps,
+  sx,
+}: Readonly<CopyableUuidProps>): React.ReactElement {
+  const { copy } = useCopyToClipboard({ type: 'text/plain' });
+  const { enqueueSnackbar } = useSnackbar();
+
+  const { sx: typographySx, ...restTypographyProps } = typographyProps ?? {};
+  const monoSx = mono ? { fontFamily: 'monospace' } : {};
+
+  if (!uuid) {
+    return (
+      <Typography
+        variant='body2'
+        color='text.secondary'
+        {...restTypographyProps}
+        sx={[monoSx, typographySx as any, sx as any].filter(Boolean) as any}
+      >
+        {placeholder}
+      </Typography>
+    );
+  }
+
+  const truncated = truncate(uuid, head, tail);
+
+  const handleCopy = async (
+    event: React.MouseEvent<HTMLElement>,
+  ): Promise<void> => {
+    event.stopPropagation();
+    try {
+      await copy(uuid);
+      enqueueSnackbar(`${label} copied to clipboard`, 'success');
+    } catch {
+      /* swallow — existing behavior */
+    }
+  };
+
+  if (variant === 'text') {
+    const textSx = {
+      cursor: 'pointer',
+      '&:hover': { textDecoration: 'underline' },
+    };
+    return (
+      <Typography
+        variant='body2'
+        onClick={handleCopy}
+        {...restTypographyProps}
+        sx={
+          [monoSx, textSx, typographySx as any, sx as any].filter(
+            Boolean,
+          ) as any
+        }
+      >
+        {truncated}
+      </Typography>
+    );
+  }
+
+  return (
+    <Stack
+      direction='row'
+      alignItems='center'
+      sx={{
+        '& .copyable-uuid__btn': { opacity: 0 },
+        '&:hover .copyable-uuid__btn': { opacity: 1 },
+        ...sx,
+      }}
+    >
+      <Typography
+        variant='body2'
+        color='text.secondary'
+        noWrap
+        {...restTypographyProps}
+        sx={[monoSx, typographySx as any].filter(Boolean) as any}
+      >
+        {truncated}
+      </Typography>
+      <IconButton
+        className='copyable-uuid__btn'
+        size='small'
+        aria-label={`Copy ${label}`}
+        onClick={handleCopy}
+        sx={{ p: 0.25, ml: 0.5 }}
+      >
+        <ContentCopy sx={{ fontSize: 13 }} />
+      </IconButton>
+    </Stack>
+  );
+}

--- a/src/components/chart/BillableEventsProductTable/BillableEventsProductTable.tsx
+++ b/src/components/chart/BillableEventsProductTable/BillableEventsProductTable.tsx
@@ -66,8 +66,8 @@ export const BillableEventsProductTable: React.FC<
       <Table sx={{ backgroundColor: white }}>
         <TableHead>
           <TableRow>
-            <TableCell>{sortLabel('brand', 'Brand')}</TableCell>
-            <TableCell>UUID</TableCell>
+            <TableCell>{sortLabel('brand', 'Brand Name')}</TableCell>
+            <TableCell>Brand UUID</TableCell>
             <TableCell>
               {sortLabel('integrationType', 'Integration Type')}
             </TableCell>
@@ -87,6 +87,10 @@ export const BillableEventsProductTable: React.FC<
                   uuid={row.brandUuid}
                   label='Brand UUID'
                   variant='button'
+                  head={6}
+                  tail={0}
+                  mono={false}
+                  iconSx={{ color: 'success.main' }}
                 />
               </TableCell>
               <TableCell>{row.integrationType}</TableCell>

--- a/src/components/chart/BillableEventsProductTable/BillableEventsProductTable.tsx
+++ b/src/components/chart/BillableEventsProductTable/BillableEventsProductTable.tsx
@@ -19,6 +19,7 @@ import {
   type BillableEventsTableRow,
 } from '../BillableEventsTable/BillableEventsTable.types';
 import { useBillableSort } from '../BillableEventsTable/useBillableSort.hook';
+import { CopyableUuid } from '../../CopyableUuid';
 import { white } from '../../../styles';
 
 const DIRECT_KEYS = ['brand', 'integrationType'];
@@ -66,6 +67,7 @@ export const BillableEventsProductTable: React.FC<
         <TableHead>
           <TableRow>
             <TableCell>{sortLabel('brand', 'Brand')}</TableCell>
+            <TableCell>UUID</TableCell>
             <TableCell>
               {sortLabel('integrationType', 'Integration Type')}
             </TableCell>
@@ -80,6 +82,13 @@ export const BillableEventsProductTable: React.FC<
           {sortedData.map((row: BillableEventsTableRow) => (
             <TableRow key={row.brandUuid}>
               <TableCell>{row.brand}</TableCell>
+              <TableCell>
+                <CopyableUuid
+                  uuid={row.brandUuid}
+                  label='Brand UUID'
+                  variant='button'
+                />
+              </TableCell>
               <TableCell>{row.integrationType}</TableCell>
               {columns.map((col: BillableEventColumn) => (
                 <TableCell key={col.key} align='right'>

--- a/src/components/chart/BillableEventsProductTable/BillableEventsProductTable.tsx
+++ b/src/components/chart/BillableEventsProductTable/BillableEventsProductTable.tsx
@@ -91,6 +91,7 @@ export const BillableEventsProductTable: React.FC<
                   tail={0}
                   mono={false}
                   iconSx={{ color: 'success.main' }}
+                  typographyProps={{ variant: 'inherit', color: 'inherit' }}
                 />
               </TableCell>
               <TableCell>{row.integrationType}</TableCell>

--- a/src/components/chart/BillableEventsTable/BillableEventsTable.tsx
+++ b/src/components/chart/BillableEventsTable/BillableEventsTable.tsx
@@ -86,7 +86,9 @@ export const BillableEventsTable: React.FC<BillableEventsTableProps> = ({
         <TableHead>
           {/* Product group header row */}
           <TableRow>
-            <TableCell rowSpan={2}>{sortLabel('brand', 'Brand Name')}</TableCell>
+            <TableCell rowSpan={2}>
+              {sortLabel('brand', 'Brand Name')}
+            </TableCell>
             <TableCell rowSpan={2}>Brand UUID</TableCell>
             <TableCell rowSpan={2}>
               {sortLabel('integrationType', 'Integration Type')}

--- a/src/components/chart/BillableEventsTable/BillableEventsTable.tsx
+++ b/src/components/chart/BillableEventsTable/BillableEventsTable.tsx
@@ -137,6 +137,7 @@ export const BillableEventsTable: React.FC<BillableEventsTableProps> = ({
                   tail={0}
                   mono={false}
                   iconSx={{ color: 'success.main' }}
+                  typographyProps={{ variant: 'inherit', color: 'inherit' }}
                 />
               </TableCell>
               <TableCell>{row.integrationType}</TableCell>

--- a/src/components/chart/BillableEventsTable/BillableEventsTable.tsx
+++ b/src/components/chart/BillableEventsTable/BillableEventsTable.tsx
@@ -20,6 +20,7 @@ import {
   type BillableEventsTableRow,
 } from './BillableEventsTable.types';
 import { useBillableSort } from './useBillableSort.hook';
+import { CopyableUuid } from '../../CopyableUuid';
 import { white } from '../../../styles';
 
 const DIRECT_KEYS = ['brand', 'integrationType'];
@@ -86,6 +87,7 @@ export const BillableEventsTable: React.FC<BillableEventsTableProps> = ({
           {/* Product group header row */}
           <TableRow>
             <TableCell rowSpan={2}>{sortLabel('brand', 'Brand')}</TableCell>
+            <TableCell rowSpan={2}>UUID</TableCell>
             <TableCell rowSpan={2}>
               {sortLabel('integrationType', 'Integration Type')}
             </TableCell>
@@ -124,6 +126,13 @@ export const BillableEventsTable: React.FC<BillableEventsTableProps> = ({
           {sortedData.map((row: BillableEventsTableRow) => (
             <TableRow key={row.brandUuid}>
               <TableCell>{row.brand}</TableCell>
+              <TableCell>
+                <CopyableUuid
+                  uuid={row.brandUuid}
+                  label='Brand UUID'
+                  variant='button'
+                />
+              </TableCell>
               <TableCell>{row.integrationType}</TableCell>
               {topLevelColumns.map((col: BillableEventColumn) => (
                 <TableCell key={col.key}>

--- a/src/components/chart/BillableEventsTable/BillableEventsTable.tsx
+++ b/src/components/chart/BillableEventsTable/BillableEventsTable.tsx
@@ -86,8 +86,8 @@ export const BillableEventsTable: React.FC<BillableEventsTableProps> = ({
         <TableHead>
           {/* Product group header row */}
           <TableRow>
-            <TableCell rowSpan={2}>{sortLabel('brand', 'Brand')}</TableCell>
-            <TableCell rowSpan={2}>UUID</TableCell>
+            <TableCell rowSpan={2}>{sortLabel('brand', 'Brand Name')}</TableCell>
+            <TableCell rowSpan={2}>Brand UUID</TableCell>
             <TableCell rowSpan={2}>
               {sortLabel('integrationType', 'Integration Type')}
             </TableCell>
@@ -131,6 +131,10 @@ export const BillableEventsTable: React.FC<BillableEventsTableProps> = ({
                   uuid={row.brandUuid}
                   label='Brand UUID'
                   variant='button'
+                  head={6}
+                  tail={0}
+                  mono={false}
+                  iconSx={{ color: 'success.main' }}
                 />
               </TableCell>
               <TableCell>{row.integrationType}</TableCell>

--- a/src/components/chart/BillableEventsTable/exportBillableEventsToCsv.ts
+++ b/src/components/chart/BillableEventsTable/exportBillableEventsToCsv.ts
@@ -42,8 +42,9 @@ export function exportBillableEventsToCsv({
 
   const rows: string[] = [];
 
-  // Row 1: Product group header
-  const groupHeader = ['', '', ...topLevelColumns.map(() => '')];
+  // Row 1: Product group header.
+  // Leading empty cells align with Brand, UUID, Integration Type, and each topLevelColumn.
+  const groupHeader = ['', '', '', ...topLevelColumns.map(() => '')];
   for (const product of activeProducts) {
     const visibleCount = product.columns.filter(
       (c) => !topLevelKeys.has(c.key),
@@ -57,7 +58,7 @@ export function exportBillableEventsToCsv({
   rows.push(groupHeader.join(','));
 
   // Row 2: Column header
-  const columnHeader = ['Brand', 'Integration Type'];
+  const columnHeader = ['Brand', 'UUID', 'Integration Type'];
   for (const col of topLevelColumns) {
     columnHeader.push(escapeCsvValue(col.label));
   }
@@ -70,6 +71,7 @@ export function exportBillableEventsToCsv({
   for (const row of data) {
     const csvRow = [
       escapeCsvValue(row.brand),
+      escapeCsvValue(row.brandUuid),
       escapeCsvValue(row.integrationType),
     ];
     for (const col of topLevelColumns) {

--- a/src/components/chart/BillableEventsTable/exportBillableEventsToCsv.ts
+++ b/src/components/chart/BillableEventsTable/exportBillableEventsToCsv.ts
@@ -58,7 +58,7 @@ export function exportBillableEventsToCsv({
   rows.push(groupHeader.join(','));
 
   // Row 2: Column header
-  const columnHeader = ['Brand', 'UUID', 'Integration Type'];
+  const columnHeader = ['Brand Name', 'Brand UUID', 'Integration Type'];
   for (const col of topLevelColumns) {
     columnHeader.push(escapeCsvValue(col.label));
   }

--- a/src/components/chart/ConversionOverTimeChart/index.tsx
+++ b/src/components/chart/ConversionOverTimeChart/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import {
   Box,
+  Stack,
   ToggleButton,
   ToggleButtonGroup,
   type SxProps,
@@ -9,6 +10,7 @@ import {
 import { EmptyChartSection } from '../EmptyChartSection';
 import { LoadingChartSection } from '../LoadingChartSection';
 import { AreaChart, type AreaSeriesChartData } from '../AreaChart';
+import { SeriesPercentageChartLegend } from '../SeriesPercentageChartLegend';
 import { useStyle } from '../styles';
 import { formatDateMMYY, formatExtendedDate } from '../../../utils/date';
 import { DEFAULT_TIMEZONE } from '../../form/TimezoneInput/timezones';
@@ -66,6 +68,15 @@ function mapBrandIntervalData({
   };
 }
 
+export interface ConversionOverTimeChartLegendBrand {
+  uuid: string;
+  value: string;
+  color: string;
+  dataKey?: string;
+  brandName?: string;
+  integrationType?: string;
+}
+
 export interface ConversionOverTimeChartProps {
   data?: Array<Record<string, number | string>>;
   series?: AreaSeriesChartData[];
@@ -80,6 +91,13 @@ export interface ConversionOverTimeChartProps {
   };
   sx?: SxProps;
   stackMode?: 'stack' | 'none';
+  /**
+   * Single-brand legend entry. When provided, renders a brand legend row
+   * beneath the chart with name, optional metadata, and a copyable UUID.
+   */
+  legendBrand?: ConversionOverTimeChartLegendBrand;
+  /** Whether the legend displays the copyable UUID. Defaults to true. */
+  showLegendUuid?: boolean;
 }
 
 export function ConversionOverTimeChart({
@@ -93,6 +111,8 @@ export function ConversionOverTimeChart({
   isSuccess,
   filter,
   sx,
+  legendBrand,
+  showLegendUuid = true,
 }: Readonly<ConversionOverTimeChartProps>): React.ReactNode {
   const style = useStyle();
   const timezone = filter.timezone ?? DEFAULT_TIMEZONE;
@@ -176,59 +196,76 @@ export function ConversionOverTimeChart({
             `${(Number(value) * 100).toFixed(1)}%`;
 
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 1,
-        height: style.regularChartWrapper.height,
-      }}
-    >
-      <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-        <ToggleButtonGroup
-          value={mode}
-          exclusive
-          onChange={(_: React.MouseEvent, value: ViewMode | null) => {
-            if (value !== null) setMode(value);
-          }}
-          size='small'
-        >
-          <ToggleButton value='absolute'>Numbers</ToggleButton>
-          <ToggleButton value='percent'>Percentages</ToggleButton>
-        </ToggleButtonGroup>
-      </Box>
-      <AreaChart
-        data={normalizedData ?? resolved.data}
-        series={resolved.series}
-        stackMode={rechartsStackMode}
-        isAnimationActive={true}
-        xAxis={{
-          dataKey: 'date',
-          type: 'number',
-          domain: ['dataMin', 'dataMax'],
-          tickFormatter: (value: number) =>
-            formatDateMMYY(value, {
-              timeZone: timezone,
-              hour12: false,
-              hour: 'numeric',
-            }),
-          allowDuplicatedCategory: false,
-        }}
-        yAxis={yAxis}
-        tooltip={{
-          formatter: tooltipFormatter,
-          labelFormatter: (value: number) =>
-            formatExtendedDate(value, { timeZone: timezone, hour12: false }),
-        }}
+    <Stack>
+      <Box
         sx={{
-          ...style.regularChartWrapper,
-          height: 'unset',
-          flex: 1,
-          minHeight: 0,
-          opacity: isFetching ? 0.4 : 1,
-          ...sx,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 1,
+          height: style.regularChartWrapper.height,
         }}
-      />
-    </Box>
+      >
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <ToggleButtonGroup
+            value={mode}
+            exclusive
+            onChange={(_: React.MouseEvent, value: ViewMode | null) => {
+              if (value !== null) setMode(value);
+            }}
+            size='small'
+          >
+            <ToggleButton value='absolute'>Numbers</ToggleButton>
+            <ToggleButton value='percent'>Percentages</ToggleButton>
+          </ToggleButtonGroup>
+        </Box>
+        <AreaChart
+          data={normalizedData ?? resolved.data}
+          series={resolved.series}
+          stackMode={rechartsStackMode}
+          isAnimationActive={true}
+          xAxis={{
+            dataKey: 'date',
+            type: 'number',
+            domain: ['dataMin', 'dataMax'],
+            tickFormatter: (value: number) =>
+              formatDateMMYY(value, {
+                timeZone: timezone,
+                hour12: false,
+                hour: 'numeric',
+              }),
+            allowDuplicatedCategory: false,
+          }}
+          yAxis={yAxis}
+          tooltip={{
+            formatter: tooltipFormatter,
+            labelFormatter: (value: number) =>
+              formatExtendedDate(value, { timeZone: timezone, hour12: false }),
+          }}
+          sx={{
+            ...style.regularChartWrapper,
+            height: 'unset',
+            flex: 1,
+            minHeight: 0,
+            opacity: isFetching ? 0.4 : 1,
+            ...sx,
+          }}
+        />
+      </Box>
+      {legendBrand && (
+        <SeriesPercentageChartLegend
+          payload={[
+            {
+              uuid: legendBrand.uuid,
+              value: legendBrand.value,
+              color: legendBrand.color,
+              dataKey: legendBrand.dataKey ?? legendBrand.uuid,
+              brandName: legendBrand.brandName,
+              integrationType: legendBrand.integrationType,
+            },
+          ]}
+          showUuid={showLegendUuid}
+        />
+      )}
+    </Stack>
   );
 }

--- a/src/components/chart/SeriesPercentageChartLegend/index.tsx
+++ b/src/components/chart/SeriesPercentageChartLegend/index.tsx
@@ -4,9 +4,8 @@ import { AnimatePresence } from 'framer-motion';
 import { type ReactElement } from 'react';
 import { type LegendProps } from 'recharts';
 
-import { useCopyToClipboard } from '../../../hooks';
 import { MotionStack } from '../../animation';
-import { useSnackbar } from '../../Snackbar';
+import { CopyableUuid } from '../../CopyableUuid';
 
 type CustomPayload = {
   uuid: string;
@@ -24,9 +23,6 @@ function EntryBlock({
   entry: CustomPayload;
   showUuid?: boolean;
 }>): ReactElement {
-  const copyToClipboard = useCopyToClipboard({ type: 'text/plain' });
-  const snackbar = useSnackbar();
-
   return (
     <MotionStack
       component='li'
@@ -57,21 +53,15 @@ function EntryBlock({
           <Typography variant='body2'>{entry.integrationType}</Typography>
         )}
         {showUuid && entry.uuid && (
-          <Typography
-            variant='body2'
-            sx={{
-              cursor: 'pointer',
-              '&:hover': { textDecoration: 'underline' },
-            }}
-            onClick={() => {
-              if (entry.uuid) {
-                copyToClipboard.copy(entry.uuid).catch(() => undefined);
-                snackbar.enqueueSnackbar('UUID copied to clipboard', 'success');
-              }
-            }}
-          >
-            {entry.uuid.slice(0, 5)}...
-          </Typography>
+          <CopyableUuid
+            uuid={entry.uuid}
+            label='UUID'
+            head={5}
+            tail={0}
+            variant='text'
+            mono={false}
+            typographyProps={{ color: 'inherit' }}
+          />
         )}
       </Stack>
     </MotionStack>
@@ -85,7 +75,7 @@ interface SeriesPercentageChartLegendProps
 }
 
 export function SeriesPercentageChartLegend(
-  props: SeriesPercentageChartLegendProps,
+  props: Readonly<SeriesPercentageChartLegendProps>,
 ): ReactElement {
   const { payload } = props;
 

--- a/src/components/chart/SynchronizedMetricsChart/SynchronizedMetricsChart.map.ts
+++ b/src/components/chart/SynchronizedMetricsChart/SynchronizedMetricsChart.map.ts
@@ -46,6 +46,7 @@ export function mapSynchronizedSubCharts({
         tooltipFormatter: config.tooltipFormatter,
         yAxisTickFormatter: config.yAxisTickFormatter,
         yAxisDomain: config.yAxisDomain,
+        isPercentage: false,
       };
     }
 
@@ -74,6 +75,7 @@ export function mapSynchronizedSubCharts({
       tooltipFormatter: config.tooltipFormatter,
       yAxisTickFormatter: config.yAxisTickFormatter,
       yAxisDomain: config.yAxisDomain,
+      isPercentage: true,
     };
   });
 

--- a/src/components/chart/SynchronizedMetricsChart/SynchronizedMetricsChart.tsx
+++ b/src/components/chart/SynchronizedMetricsChart/SynchronizedMetricsChart.tsx
@@ -1,5 +1,6 @@
-import React, { useMemo } from 'react';
-import { Stack, Typography, useTheme } from '@mui/material';
+import React, { useMemo, useState } from 'react';
+import { Stack, ToggleButton, Typography, useTheme } from '@mui/material';
+import { scaleSymlog } from 'd3-scale';
 import {
   LineChart as RechartsLineChart,
   Line,
@@ -29,13 +30,17 @@ import { mapSynchronizedSubCharts } from './SynchronizedMetricsChart.map';
 
 const SYNC_ID = 'synchronized-metrics';
 const CHART_HEIGHT = 200;
+const TOTAL_KEY = '__total__';
+const TOTAL_NAME = 'Total';
 
 /**
  * Merges per-brand SeriesChartData into a flat array for chart-level data.
  * Each entry: { date, [brand1.uuid]: value, [brand2.uuid]: value, ... }
  * This is required for Recharts syncId tooltip sync to work across charts.
+ *
+ * Exported for testing.
  */
-function mergeChartData(
+export function mergeChartData(
   seriesData: SeriesChartData[],
 ): Array<Record<string, number>> {
   const dateMap = new Map<number, Record<string, number> & { date: number }>();
@@ -54,12 +59,32 @@ function mergeChartData(
   return Array.from(dateMap.values()).sort((a, b) => a.date - b.date);
 }
 
+/** Exported for testing. */
+export const TOTAL_DATA_KEY = TOTAL_KEY;
+
+export function enrichWithTotal(
+  entries: Array<Record<string, number>>,
+  visibleBrandKeys: string[],
+): Array<Record<string, number>> {
+  if (!visibleBrandKeys.length) return entries;
+  return entries.map((entry) => ({
+    ...entry,
+    [TOTAL_KEY]: visibleBrandKeys.reduce(
+      (sum, key) => sum + (Number(entry[key]) || 0),
+      0,
+    ),
+  }));
+}
+
 interface SubChartProps {
   title: string;
   mergedData: Array<Record<string, number>>;
   brands: SeriesChartData[];
   timezone: string;
   syncId: string;
+  isPercentage: boolean;
+  showTotal: boolean;
+  logScale: boolean;
   tooltipFormatter?: (value: number | string) => string;
   yAxisTickFormatter?: (value: number) => string;
   yAxisDomain?: [number | string, number | string];
@@ -71,11 +96,17 @@ function SubChart({
   brands,
   timezone,
   syncId,
+  isPercentage,
+  showTotal,
+  logScale,
   tooltipFormatter,
   yAxisTickFormatter,
   yAxisDomain,
-}: SubChartProps): React.ReactNode {
+}: Readonly<SubChartProps>): React.ReactNode {
   const theme = useTheme();
+  const useLogScale = logScale && !isPercentage;
+  const showTotalLine = showTotal && !isPercentage && brands.length > 1;
+  const yAxisScale = useLogScale ? scaleSymlog() : undefined;
 
   return (
     <Stack>
@@ -106,6 +137,7 @@ function SubChart({
             }
             allowDecimals={false}
             domain={yAxisDomain}
+            scale={yAxisScale}
             {...yAxisDefaultProps}
           />
           <Tooltip
@@ -134,6 +166,19 @@ function SubChart({
               dot={false}
             />
           ))}
+          {showTotalLine && (
+            <Line
+              key={TOTAL_KEY}
+              dataKey={TOTAL_KEY}
+              name={TOTAL_NAME}
+              stroke={theme.palette.text.primary}
+              strokeWidth={2}
+              strokeDasharray='4 4'
+              type='monotone'
+              isAnimationActive={false}
+              dot={false}
+            />
+          )}
         </RechartsLineChart>
       </ResponsiveContainer>
     </Stack>
@@ -153,6 +198,8 @@ export function SynchronizedMetricsChart({
   sx,
 }: Readonly<SynchronizedMetricsChartProps>): React.ReactNode {
   const timezone = filter.timezone ?? DEFAULT_TIMEZONE;
+  const [showTotal, setShowTotal] = useState(false);
+  const [logScale, setLogScale] = useState(false);
 
   const resolvedSubCharts: readonly [SubChartConfig, ...SubChartConfig[]] =
     chartData
@@ -168,8 +215,19 @@ export function SynchronizedMetricsChart({
   const noData = resolvedSubCharts.every((sc) => sc.data.length === 0);
 
   const mergedSubCharts = useMemo(
-    () => resolvedSubCharts.map((sc) => mergeChartData(sc.data)),
+    () =>
+      resolvedSubCharts.map((sc) => {
+        const merged = mergeChartData(sc.data);
+        if (sc.isPercentage) return merged;
+        const visibleKeys = sc.data.map((brand) => brand.uuid);
+        return enrichWithTotal(merged, visibleKeys);
+      }),
     [resolvedSubCharts],
+  );
+
+  const hasAbsoluteSubChart = resolvedSubCharts.some((sc) => !sc.isPercentage);
+  const hasAbsoluteMultiBrand = resolvedSubCharts.some(
+    (sc) => !sc.isPercentage && sc.data.length > 1,
   );
 
   const legendPayload = useMemo(
@@ -193,8 +251,43 @@ export function SynchronizedMetricsChart({
     return <EmptyChartSection />;
   }
 
+  const showControls = hasAbsoluteSubChart || hasAbsoluteMultiBrand;
+
   return (
     <Stack sx={{ width: '100%', ...sx }}>
+      {showControls && (
+        <Stack
+          direction='row'
+          spacing={1}
+          justifyContent='flex-end'
+          sx={{ mb: 1 }}
+        >
+          {hasAbsoluteMultiBrand && (
+            <ToggleButton
+              value='total'
+              selected={showTotal}
+              onChange={() => setShowTotal((v) => !v)}
+              size='small'
+              aria-label='Show Total line'
+              aria-pressed={showTotal}
+            >
+              Show Total
+            </ToggleButton>
+          )}
+          {hasAbsoluteSubChart && (
+            <ToggleButton
+              value='log'
+              selected={logScale}
+              onChange={() => setLogScale((v) => !v)}
+              size='small'
+              aria-label='Toggle logarithmic scale'
+              aria-pressed={logScale}
+            >
+              Log Scale
+            </ToggleButton>
+          )}
+        </Stack>
+      )}
       <Stack sx={{ opacity: isFetching ? 0.4 : 1, gap: 2 }}>
         {resolvedSubCharts.map((sc, i) => (
           <SubChart
@@ -204,6 +297,9 @@ export function SynchronizedMetricsChart({
             brands={sc.data}
             timezone={timezone}
             syncId={syncId}
+            isPercentage={sc.isPercentage ?? false}
+            showTotal={showTotal}
+            logScale={logScale}
             tooltipFormatter={sc.tooltipFormatter}
             yAxisTickFormatter={sc.yAxisTickFormatter}
             yAxisDomain={sc.yAxisDomain}

--- a/src/components/chart/SynchronizedMetricsChart/SynchronizedMetricsChart.types.ts
+++ b/src/components/chart/SynchronizedMetricsChart/SynchronizedMetricsChart.types.ts
@@ -10,6 +10,11 @@ export interface SubChartConfig {
   tooltipFormatter?: (value: number | string) => string;
   yAxisTickFormatter?: (value: number) => string;
   yAxisDomain?: [number | string, number | string];
+  /**
+   * Marks this sub-chart as showing percentage values. Percentage sub-charts
+   * opt out of the Total line and the Log Scale toggle.
+   */
+  isPercentage?: boolean;
 }
 
 export type SynchronizedSubChartConfig =

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -22,3 +22,4 @@ export * from './icons';
 export * from './UI';
 export * from './text-to-signup';
 export * from './logs';
+export * from './CopyableUuid';

--- a/src/components/logs/LogsTable/LogsTable.tsx
+++ b/src/components/logs/LogsTable/LogsTable.tsx
@@ -23,6 +23,7 @@ import { ContentCopy } from '@mui/icons-material';
 import { EmptyChartSection } from '../../chart/EmptyChartSection';
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
 import { useSnackbar } from '../../Snackbar';
+import { CopyableUuid } from '../../CopyableUuid';
 import { formatLogTimestamp } from '../../../utils/date';
 import type { LogEntry, LogsResponse } from '../types';
 import { PRODUCT_LABELS } from '../constants';
@@ -93,18 +94,6 @@ function CopyButton({
       <ContentCopy sx={{ fontSize: 13 }} />
     </IconButton>
   );
-}
-
-function truncateUuid(uuid: string | null): string {
-  if (!uuid) {
-    return '—';
-  }
-
-  if (uuid.length <= 12) {
-    return uuid;
-  }
-
-  return `${uuid.slice(0, 4)}…${uuid.slice(-4)}`;
 }
 
 function formatEvent(row: LogEntry): string {
@@ -420,33 +409,13 @@ export function LogsTable({
                         )}
                       </Stack>
                     </TableCell>
-                    <TableCell
-                      sx={{
-                        '& .copy-btn': { opacity: 0 },
-                        '&:hover .copy-btn': { opacity: 1 },
-                      }}
-                    >
-                      <Stack
-                        direction='row'
-                        alignItems='center'
-                        overflow='hidden'
-                      >
-                        <Typography
-                          variant='body2'
-                          color='text.secondary'
-                          noWrap
-                          sx={monoSx}
-                        >
-                          {truncateUuid(row.uuid)}
-                        </Typography>
-                        {row.uuid && (
-                          <CopyButton
-                            value={row.uuid}
-                            label='1-Click UUID'
-                            onCopy={handleCopy}
-                          />
-                        )}
-                      </Stack>
+                    <TableCell>
+                      <CopyableUuid
+                        uuid={row.uuid}
+                        label='1-Click UUID'
+                        variant='button'
+                        typographyProps={{ sx: monoSx }}
+                      />
                     </TableCell>
                     <TableCell>
                       <Chip

--- a/src/components/logs/LogsTable/LogsTable.tsx
+++ b/src/components/logs/LogsTable/LogsTable.tsx
@@ -23,7 +23,6 @@ import { ContentCopy } from '@mui/icons-material';
 import { EmptyChartSection } from '../../chart/EmptyChartSection';
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
 import { useSnackbar } from '../../Snackbar';
-import { CopyableUuid } from '../../CopyableUuid';
 import { formatLogTimestamp } from '../../../utils/date';
 import type { LogEntry, LogsResponse } from '../types';
 import { PRODUCT_LABELS } from '../constants';
@@ -94,6 +93,18 @@ function CopyButton({
       <ContentCopy sx={{ fontSize: 13 }} />
     </IconButton>
   );
+}
+
+function truncateUuid(uuid: string | null): string {
+  if (!uuid) {
+    return '—';
+  }
+
+  if (uuid.length <= 12) {
+    return uuid;
+  }
+
+  return `${uuid.slice(0, 4)}…${uuid.slice(-4)}`;
 }
 
 function formatEvent(row: LogEntry): string {
@@ -409,13 +420,33 @@ export function LogsTable({
                         )}
                       </Stack>
                     </TableCell>
-                    <TableCell>
-                      <CopyableUuid
-                        uuid={row.uuid}
-                        label='1-Click UUID'
-                        variant='button'
-                        typographyProps={{ sx: monoSx }}
-                      />
+                    <TableCell
+                      sx={{
+                        '& .copy-btn': { opacity: 0 },
+                        '&:hover .copy-btn': { opacity: 1 },
+                      }}
+                    >
+                      <Stack
+                        direction='row'
+                        alignItems='center'
+                        overflow='hidden'
+                      >
+                        <Typography
+                          variant='body2'
+                          color='text.secondary'
+                          noWrap
+                          sx={monoSx}
+                        >
+                          {truncateUuid(row.uuid)}
+                        </Typography>
+                        {row.uuid && (
+                          <CopyButton
+                            value={row.uuid}
+                            label='1-Click UUID'
+                            onCopy={handleCopy}
+                          />
+                        )}
+                      </Stack>
                     </TableCell>
                     <TableCell>
                       <Chip

--- a/src/stories/components/chart/BillableEventsMonthlyTable.stories.tsx
+++ b/src/stories/components/chart/BillableEventsMonthlyTable.stories.tsx
@@ -31,8 +31,8 @@ const mockData = [
     raw: {
       brandUuid: 'c44d24d0-8cef-4fcc-ad37-1fe154d97e57',
       brandName: 'Hooli Health',
-      overall: {}
-    }
+      overall: {},
+    },
   },
   {
     brandUuid: '',
@@ -50,8 +50,8 @@ const mockData = [
     raw: {
       brandUuid: '',
       brandName: 'Pied Piper',
-      overall: {}
-    }
+      overall: {},
+    },
   },
   {
     brandUuid: '42f12a06-47a7-46bf-901b-e4a8227266d0',
@@ -69,8 +69,8 @@ const mockData = [
     raw: {
       brandUuid: '42f12a06-47a7-46bf-901b-e4a8227266d0',
       brandName: 'Aviato',
-      overall: {}
-    }
+      overall: {},
+    },
   },
 ];
 

--- a/src/stories/components/chart/BillableEventsMonthlyTable.stories.tsx
+++ b/src/stories/components/chart/BillableEventsMonthlyTable.stories.tsx
@@ -16,7 +16,7 @@ type Story = StoryObj<typeof BillableEventsProductTable>;
 
 const mockData = [
   {
-    brandUuid: '101',
+    brandUuid: 'c44d24d0-8cef-4fcc-ad37-1fe154d97e57',
     brand: 'Hooli Health',
     integrationType: 'SDK',
     metrics: {
@@ -28,9 +28,14 @@ const mockData = [
       signup_riskSignals: 8,
       health_autofillsStarted: 13,
     },
+    raw: {
+      brandUuid: 'c44d24d0-8cef-4fcc-ad37-1fe154d97e57',
+      brandName: 'Hooli Health',
+      overall: {}
+    }
   },
   {
-    brandUuid: '102',
+    brandUuid: '',
     brand: 'Pied Piper',
     integrationType: 'API',
     metrics: {
@@ -42,9 +47,14 @@ const mockData = [
       signup_riskSignals: 3,
       health_autofillsStarted: 45,
     },
+    raw: {
+      brandUuid: '',
+      brandName: 'Pied Piper',
+      overall: {}
+    }
   },
   {
-    brandUuid: '103',
+    brandUuid: '42f12a06-47a7-46bf-901b-e4a8227266d0',
     brand: 'Aviato',
     integrationType: 'Semi-Hosted',
     metrics: {
@@ -56,6 +66,11 @@ const mockData = [
       signup_riskSignals: 14,
       health_autofillsStarted: 3,
     },
+    raw: {
+      brandUuid: '42f12a06-47a7-46bf-901b-e4a8227266d0',
+      brandName: 'Aviato',
+      overall: {}
+    }
   },
 ];
 

--- a/src/stories/components/chart/BillableEventsTable.stories.tsx
+++ b/src/stories/components/chart/BillableEventsTable.stories.tsx
@@ -22,10 +22,14 @@ type Story = StoryObj<typeof BillableEventsTable>;
 
 const mockData: BillableEventsTableRow[] = [
   {
-    brandUuid: '101',
+    brandUuid: 'c44d24d0-8cef-4fcc-ad37-1fe154d97e57',
     brand: 'Hooli Health',
     integrationType: 'SDK',
-    raw: { brandUuid: '101', brandName: 'Hooli Health', overall: {} },
+    raw: {
+      brandUuid: 'c44d24d0-8cef-4fcc-ad37-1fe154d97e57',
+      brandName: 'Hooli Health',
+      overall: {},
+    },
     metrics: {
       tts_smsKeywordsReceived: 4,
       tts_verificationsSucceeded: 3,
@@ -37,10 +41,10 @@ const mockData: BillableEventsTableRow[] = [
     },
   },
   {
-    brandUuid: '102',
+    brandUuid: '',
     brand: 'Pied Piper',
     integrationType: 'API',
-    raw: { brandUuid: '102', brandName: 'Pied Piper', overall: {} },
+    raw: { brandUuid: '', brandName: 'Pied Piper', overall: {} },
     metrics: {
       tts_smsKeywordsReceived: 12,
       tts_verificationsSucceeded: 10,
@@ -52,10 +56,14 @@ const mockData: BillableEventsTableRow[] = [
     },
   },
   {
-    brandUuid: '103',
+    brandUuid: '42f12a06-47a7-46bf-901b-e4a8227266d0',
     brand: 'Aviato',
     integrationType: 'Semi-Hosted',
-    raw: { brandUuid: '103', brandName: 'Aviato', overall: {} },
+    raw: {
+      brandUuid: '42f12a06-47a7-46bf-901b-e4a8227266d0',
+      brandName: 'Aviato',
+      overall: {},
+    },
     metrics: {
       tts_smsKeywordsReceived: 0,
       tts_verificationsSucceeded: 0,

--- a/src/stories/components/chart/OneClickHealthConversionChart.stories.tsx
+++ b/src/stories/components/chart/OneClickHealthConversionChart.stories.tsx
@@ -4,11 +4,31 @@ import { Box, Stack } from '@mui/material';
 import { ConversionOverTimeChart } from '../../../components/chart';
 import { blue, green } from '../../../styles/colors';
 
+const sampleLegendBrand = {
+  uuid: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  value: 'Aviato Health',
+  color: green,
+  brandName: 'Aviato Health Production',
+  integrationType: 'Hosted',
+};
+
 const meta = {
   title: 'components/chart/ConversionOverTimeChart/HealthConversion',
   component: ConversionOverTimeChart,
   parameters: {
     layout: 'centered',
+  },
+  argTypes: {
+    showLegendUuid: {
+      control: 'boolean',
+      table: { type: { summary: 'boolean' } },
+    },
+    legendBrand: {
+      control: 'object',
+      table: {
+        type: { summary: 'ConversionOverTimeChartLegendBrand | undefined' },
+      },
+    },
   },
   decorators: [
     (Story) => (
@@ -161,5 +181,33 @@ export const Fetching: Story = {
     isSuccess: true,
     isFetching: true,
     filter: { timezone: 'UTC' },
+  },
+};
+
+export const WithLegend: Story = {
+  args: {
+    chartData: mockRawData,
+    seriesConfig,
+    stackMode: 'none',
+    isLoading: false,
+    isSuccess: true,
+    isFetching: false,
+    filter: { timezone: 'UTC' },
+    legendBrand: sampleLegendBrand,
+    showLegendUuid: true,
+  },
+};
+
+export const WithLegendNoUuid: Story = {
+  args: {
+    chartData: mockRawData,
+    seriesConfig,
+    stackMode: 'none',
+    isLoading: false,
+    isSuccess: true,
+    isFetching: false,
+    filter: { timezone: 'UTC' },
+    legendBrand: sampleLegendBrand,
+    showLegendUuid: false,
   },
 };

--- a/src/stories/components/chart/OneClickSignupConversionChart.stories.tsx
+++ b/src/stories/components/chart/OneClickSignupConversionChart.stories.tsx
@@ -4,11 +4,31 @@ import { Box, Stack } from '@mui/material';
 import { ConversionOverTimeChart } from '../../../components/chart';
 import { blue, green } from '../../../styles/colors';
 
+const sampleLegendBrand = {
+  uuid: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  value: 'Aviato Health',
+  color: green,
+  brandName: 'Aviato Health Production',
+  integrationType: 'Hosted',
+};
+
 const meta = {
   title: 'components/chart/ConversionOverTimeChart/SignupConversion',
   component: ConversionOverTimeChart,
   parameters: {
     layout: 'centered',
+  },
+  argTypes: {
+    showLegendUuid: {
+      control: 'boolean',
+      table: { type: { summary: 'boolean' } },
+    },
+    legendBrand: {
+      control: 'object',
+      table: {
+        type: { summary: 'ConversionOverTimeChartLegendBrand | undefined' },
+      },
+    },
   },
   decorators: [
     (Story) => (
@@ -161,5 +181,33 @@ export const Fetching: Story = {
     isSuccess: true,
     isFetching: true,
     filter: { timezone: 'UTC' },
+  },
+};
+
+export const WithLegend: Story = {
+  args: {
+    chartData: mockRawData,
+    seriesConfig,
+    stackMode: 'none',
+    isLoading: false,
+    isSuccess: true,
+    isFetching: false,
+    filter: { timezone: 'UTC' },
+    legendBrand: sampleLegendBrand,
+    showLegendUuid: true,
+  },
+};
+
+export const WithLegendNoUuid: Story = {
+  args: {
+    chartData: mockRawData,
+    seriesConfig,
+    stackMode: 'none',
+    isLoading: false,
+    isSuccess: true,
+    isFetching: false,
+    filter: { timezone: 'UTC' },
+    legendBrand: sampleLegendBrand,
+    showLegendUuid: false,
   },
 };

--- a/src/stories/components/chart/OneClickVerificationConversionChart.stories.tsx
+++ b/src/stories/components/chart/OneClickVerificationConversionChart.stories.tsx
@@ -4,11 +4,31 @@ import { Box, Stack } from '@mui/material';
 import { ConversionOverTimeChart } from '../../../components/chart';
 import { blue, green } from '../../../styles/colors';
 
+const sampleLegendBrand = {
+  uuid: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  value: 'Aviato Health',
+  color: green,
+  brandName: 'Aviato Health Production',
+  integrationType: 'Hosted',
+};
+
 const meta = {
   title: 'components/chart/ConversionOverTimeChart/VerificationConversion',
   component: ConversionOverTimeChart,
   parameters: {
     layout: 'centered',
+  },
+  argTypes: {
+    showLegendUuid: {
+      control: 'boolean',
+      table: { type: { summary: 'boolean' } },
+    },
+    legendBrand: {
+      control: 'object',
+      table: {
+        type: { summary: 'ConversionOverTimeChartLegendBrand | undefined' },
+      },
+    },
   },
   decorators: [
     (Story) => (
@@ -231,5 +251,33 @@ export const Fetching: Story = {
     isSuccess: true,
     isFetching: true,
     filter: { timezone: 'UTC' },
+  },
+};
+
+export const WithLegend: Story = {
+  args: {
+    chartData: mockRawData,
+    seriesConfig,
+    stackMode: 'none',
+    isLoading: false,
+    isSuccess: true,
+    isFetching: false,
+    filter: { timezone: 'UTC' },
+    legendBrand: sampleLegendBrand,
+    showLegendUuid: true,
+  },
+};
+
+export const WithLegendNoUuid: Story = {
+  args: {
+    chartData: mockRawData,
+    seriesConfig,
+    stackMode: 'none',
+    isLoading: false,
+    isSuccess: true,
+    isFetching: false,
+    filter: { timezone: 'UTC' },
+    legendBrand: sampleLegendBrand,
+    showLegendUuid: false,
   },
 };

--- a/src/stories/components/chart/OneClickVerificationDeliveryChart.stories.tsx
+++ b/src/stories/components/chart/OneClickVerificationDeliveryChart.stories.tsx
@@ -4,11 +4,31 @@ import { Box, Stack } from '@mui/material';
 import { ConversionOverTimeChart } from '../../../components/chart';
 import { blue, green } from '../../../styles/colors';
 
+const sampleLegendBrand = {
+  uuid: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  value: 'Aviato Health',
+  color: green,
+  brandName: 'Aviato Health Production',
+  integrationType: 'Hosted',
+};
+
 const meta = {
   title: 'components/chart/ConversionOverTimeChart/VerificationDelivery',
   component: ConversionOverTimeChart,
   parameters: {
     layout: 'centered',
+  },
+  argTypes: {
+    showLegendUuid: {
+      control: 'boolean',
+      table: { type: { summary: 'boolean' } },
+    },
+    legendBrand: {
+      control: 'object',
+      table: {
+        type: { summary: 'ConversionOverTimeChartLegendBrand | undefined' },
+      },
+    },
   },
   decorators: [
     (Story) => (
@@ -231,5 +251,33 @@ export const Fetching: Story = {
     isSuccess: true,
     isFetching: true,
     filter: { timezone: 'UTC' },
+  },
+};
+
+export const WithLegend: Story = {
+  args: {
+    chartData: mockRawData,
+    seriesConfig,
+    stackMode: 'none',
+    isLoading: false,
+    isSuccess: true,
+    isFetching: false,
+    filter: { timezone: 'UTC' },
+    legendBrand: sampleLegendBrand,
+    showLegendUuid: true,
+  },
+};
+
+export const WithLegendNoUuid: Story = {
+  args: {
+    chartData: mockRawData,
+    seriesConfig,
+    stackMode: 'none',
+    isLoading: false,
+    isSuccess: true,
+    isFetching: false,
+    filter: { timezone: 'UTC' },
+    legendBrand: sampleLegendBrand,
+    showLegendUuid: false,
   },
 };

--- a/src/stories/components/chart/OneClickVerificationOutcomeOverTimeChart.stories.tsx
+++ b/src/stories/components/chart/OneClickVerificationOutcomeOverTimeChart.stories.tsx
@@ -4,11 +4,31 @@ import { Box, Stack } from '@mui/material';
 import { ConversionOverTimeChart } from '../../../components/chart';
 import { green, yellow, red } from '../../../styles/colors';
 
+const sampleLegendBrand = {
+  uuid: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  value: 'Aviato Health',
+  color: green,
+  brandName: 'Aviato Health Production',
+  integrationType: 'Hosted',
+};
+
 const meta = {
   title: 'components/chart/OneClickVerificationOutcomeOverTimeChart',
   component: ConversionOverTimeChart,
   parameters: {
     layout: 'centered',
+  },
+  argTypes: {
+    showLegendUuid: {
+      control: 'boolean',
+      table: { type: { summary: 'boolean' } },
+    },
+    legendBrand: {
+      control: 'object',
+      table: {
+        type: { summary: 'ConversionOverTimeChartLegendBrand | undefined' },
+      },
+    },
   },
   decorators: [
     (Story) => (
@@ -244,5 +264,33 @@ export const StackModeNone: Story = {
     isSuccess: true,
     isFetching: false,
     filter: { timezone: 'UTC' },
+  },
+};
+
+export const WithLegend: Story = {
+  args: {
+    chartData: mockRawData,
+    seriesConfig,
+    stackMode: 'stack',
+    isLoading: false,
+    isSuccess: true,
+    isFetching: false,
+    filter: { timezone: 'UTC' },
+    legendBrand: sampleLegendBrand,
+    showLegendUuid: true,
+  },
+};
+
+export const WithLegendNoUuid: Story = {
+  args: {
+    chartData: mockRawData,
+    seriesConfig,
+    stackMode: 'stack',
+    isLoading: false,
+    isSuccess: true,
+    isFetching: false,
+    filter: { timezone: 'UTC' },
+    legendBrand: sampleLegendBrand,
+    showLegendUuid: false,
   },
 };

--- a/tests/components/CopyableUuid.test.tsx
+++ b/tests/components/CopyableUuid.test.tsx
@@ -1,0 +1,120 @@
+import { expect, test, describe, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+
+import { CopyableUuid } from '../../src/components/CopyableUuid';
+
+const FULL_UUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+class MockClipboardItem {
+  constructor(public readonly items: Record<string, unknown>) {}
+}
+
+let clipboardWrite: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  clipboardWrite = vi.fn().mockResolvedValue(undefined);
+  // jsdom doesn't ship a Clipboard API — stub navigator.clipboard.write and ClipboardItem.
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { write: clipboardWrite },
+  });
+  (
+    globalThis as unknown as { ClipboardItem: typeof MockClipboardItem }
+  ).ClipboardItem = MockClipboardItem;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('<CopyableUuid/>', () => {
+  test('renders placeholder when uuid is nullish', () => {
+    const { getByText, rerender } = render(<CopyableUuid uuid={null} />);
+    expect(getByText('—')).toBeDefined();
+
+    rerender(<CopyableUuid uuid={undefined} />);
+    expect(getByText('—')).toBeDefined();
+
+    rerender(<CopyableUuid uuid='' />);
+    expect(getByText('—')).toBeDefined();
+  });
+
+  test('renders a custom placeholder', () => {
+    const { getByText } = render(
+      <CopyableUuid uuid={null} placeholder='not set' />,
+    );
+    expect(getByText('not set')).toBeDefined();
+  });
+
+  test('button variant truncates uuid (head + tail)', () => {
+    const { container } = render(
+      <CopyableUuid uuid={FULL_UUID} variant='button' head={4} tail={4} />,
+    );
+    // head "a1b2" + ellipsis + tail "7890"
+    expect(container.textContent).toContain('a1b2');
+    expect(container.textContent).toContain('7890');
+    expect(container.textContent).not.toContain(FULL_UUID);
+  });
+
+  test('text variant with tail=0 uses head-only format', () => {
+    const { container } = render(
+      <CopyableUuid uuid={FULL_UUID} variant='text' head={5} tail={0} />,
+    );
+    expect(container.textContent).toContain('a1b2c...');
+    expect(container.textContent).not.toContain(FULL_UUID);
+  });
+
+  test('returns the full uuid when it is short enough to not need truncating', () => {
+    const short = 'abc123';
+    const { getByText } = render(
+      <CopyableUuid uuid={short} head={4} tail={4} />,
+    );
+    expect(getByText(short)).toBeDefined();
+  });
+
+  test('button variant copies full uuid to clipboard on icon click', async () => {
+    const { getByLabelText } = render(
+      <CopyableUuid uuid={FULL_UUID} label='Brand UUID' variant='button' />,
+    );
+
+    const copyButton = getByLabelText('Copy Brand UUID');
+    fireEvent.click(copyButton);
+
+    await waitFor(() => expect(clipboardWrite).toHaveBeenCalledTimes(1));
+    // The clipboard payload should contain the full UUID.
+    const [clipboardItems] = clipboardWrite.mock.calls[0];
+    expect(Array.isArray(clipboardItems)).toBe(true);
+    expect(clipboardItems[0]).toBeInstanceOf(MockClipboardItem);
+  });
+
+  test('text variant copies full uuid to clipboard on text click', async () => {
+    const { container } = render(
+      <CopyableUuid
+        uuid={FULL_UUID}
+        label='UUID'
+        variant='text'
+        head={5}
+        tail={0}
+      />,
+    );
+
+    const text = container.querySelector('p, span');
+    expect(text).not.toBeNull();
+    fireEvent.click(text as Element);
+
+    await waitFor(() => expect(clipboardWrite).toHaveBeenCalledTimes(1));
+  });
+
+  test('swallows clipboard failures silently', async () => {
+    clipboardWrite.mockRejectedValueOnce(new Error('denied'));
+    const { getByLabelText } = render(
+      <CopyableUuid uuid={FULL_UUID} label='UUID' variant='button' />,
+    );
+
+    fireEvent.click(getByLabelText('Copy UUID'));
+
+    // Should not throw; clipboard was invoked.
+    await waitFor(() => expect(clipboardWrite).toHaveBeenCalledTimes(1));
+  });
+});

--- a/tests/components/CopyableUuid.test.tsx
+++ b/tests/components/CopyableUuid.test.tsx
@@ -88,8 +88,8 @@ describe('<CopyableUuid/>', () => {
     expect(clipboardItems[0]).toBeInstanceOf(MockClipboardItem);
   });
 
-  test('text variant copies full uuid to clipboard on text click', async () => {
-    const { container } = render(
+  test('text variant copies full uuid to clipboard on click', async () => {
+    const { getByRole } = render(
       <CopyableUuid
         uuid={FULL_UUID}
         label='UUID'
@@ -99,11 +99,26 @@ describe('<CopyableUuid/>', () => {
       />,
     );
 
-    const text = container.querySelector('p, span');
-    expect(text).not.toBeNull();
-    fireEvent.click(text as Element);
+    const button = getByRole('button', { name: 'Copy UUID' });
+    fireEvent.click(button);
 
     await waitFor(() => expect(clipboardWrite).toHaveBeenCalledTimes(1));
+  });
+
+  test('text variant renders as a real button (keyboard accessible)', () => {
+    const { getByRole } = render(
+      <CopyableUuid
+        uuid={FULL_UUID}
+        label='UUID'
+        variant='text'
+        head={5}
+        tail={0}
+      />,
+    );
+
+    const button = getByRole('button', { name: 'Copy UUID' });
+    expect(button.tagName).toBe('BUTTON');
+    expect(button.getAttribute('type')).toBe('button');
   });
 
   test('swallows clipboard failures silently', async () => {

--- a/tests/components/chart/SynchronizedMetricsChart.test.tsx
+++ b/tests/components/chart/SynchronizedMetricsChart.test.tsx
@@ -1,0 +1,220 @@
+import { afterEach, beforeAll, expect, test, describe } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { createTheme, ThemeProvider } from '@mui/material';
+
+// Recharts' ResponsiveContainer uses ResizeObserver, which jsdom doesn't provide.
+beforeAll(() => {
+  class MockResizeObserver {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  (
+    globalThis as unknown as { ResizeObserver: typeof MockResizeObserver }
+  ).ResizeObserver = MockResizeObserver;
+});
+
+import {
+  SynchronizedMetricsChart,
+  enrichWithTotal,
+  mergeChartData,
+  TOTAL_DATA_KEY,
+} from '../../../src/components/chart/SynchronizedMetricsChart/SynchronizedMetricsChart';
+import type { SubChartConfig } from '../../../src/components/chart/SynchronizedMetricsChart/SynchronizedMetricsChart.types';
+import type { SeriesChartData } from '../../../src/components/chart/SeriesChart';
+
+// Minimal theme — just enough to satisfy theme.palette.neutral access.
+const testTheme = createTheme({
+  palette: {
+    // Registered in src/styles/theme.ts module augmentation; createTheme
+    // accepts the augmented keys once the types are in scope.
+    neutral: { main: '#999999' },
+    neutralContrast: { main: '#cccccc' },
+    warningContrast: { main: '#ff9800' },
+    infoContrast: { main: '#2196f3' },
+    dangerContrast: { main: '#f44336' },
+  },
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function brand(
+  uuid: string,
+  name: string,
+  color: string,
+  points: Array<[number, number]>,
+): SeriesChartData {
+  return {
+    uuid,
+    name,
+    color,
+    brandUuid: uuid,
+    brandName: name,
+    chartData: points.map(([date, value]) => ({ date, value })),
+  };
+}
+
+const DATE_A = Date.UTC(2026, 0, 10);
+const DATE_B = Date.UTC(2026, 0, 11);
+const DATE_C = Date.UTC(2026, 0, 12);
+
+describe('mergeChartData', () => {
+  test('merges brands into date-keyed entries sorted ascending', () => {
+    const brands: SeriesChartData[] = [
+      brand('brand-1', 'Brand 1', '#111', [
+        [DATE_B, 10],
+        [DATE_A, 5],
+      ]),
+      brand('brand-2', 'Brand 2', '#222', [
+        [DATE_A, 3],
+        [DATE_C, 7],
+      ]),
+    ];
+
+    const merged = mergeChartData(brands);
+
+    expect(merged).toHaveLength(3);
+    expect(merged[0]).toEqual({ date: DATE_A, 'brand-1': 5, 'brand-2': 3 });
+    expect(merged[1]).toEqual({ date: DATE_B, 'brand-1': 10 });
+    expect(merged[2]).toEqual({ date: DATE_C, 'brand-2': 7 });
+  });
+});
+
+describe('enrichWithTotal', () => {
+  test('adds __total__ summed across visible brands per entry', () => {
+    const merged: Array<Record<string, number>> = [
+      { date: DATE_A, 'brand-1': 5, 'brand-2': 3 },
+      { date: DATE_B, 'brand-1': 10 },
+    ];
+
+    const enriched = enrichWithTotal(merged, ['brand-1', 'brand-2']);
+
+    expect(enriched[0][TOTAL_DATA_KEY]).toBe(8);
+    // Missing brand key counts as 0 (not NaN).
+    expect(enriched[1][TOTAL_DATA_KEY]).toBe(10);
+  });
+
+  test('only sums the brand keys passed in as visible', () => {
+    const merged: Array<Record<string, number>> = [
+      { date: DATE_A, 'brand-1': 5, 'brand-2': 3, 'brand-3': 11 },
+    ];
+
+    const enriched = enrichWithTotal(merged, ['brand-1', 'brand-3']);
+
+    expect(enriched[0][TOTAL_DATA_KEY]).toBe(16);
+  });
+
+  test('is a no-op when visibleBrandKeys is empty (returns the same entries)', () => {
+    const merged: Array<Record<string, number>> = [
+      { date: DATE_A, 'brand-1': 5 },
+    ];
+    const enriched = enrichWithTotal(merged, []);
+
+    expect(enriched).toBe(merged);
+  });
+});
+
+const multiBrandAbsolute: SubChartConfig = {
+  title: 'Started',
+  isPercentage: false,
+  data: [
+    brand('brand-1', 'Brand 1', '#111', [
+      [DATE_A, 5],
+      [DATE_B, 10],
+    ]),
+    brand('brand-2', 'Brand 2', '#222', [
+      [DATE_A, 3],
+      [DATE_B, 7],
+    ]),
+  ],
+};
+
+const singleBrandAbsolute: SubChartConfig = {
+  title: 'Started',
+  isPercentage: false,
+  data: [
+    brand('brand-1', 'Brand 1', '#111', [
+      [DATE_A, 5],
+      [DATE_B, 10],
+    ]),
+  ],
+};
+
+const percentageSubChart: SubChartConfig = {
+  title: 'Success %',
+  isPercentage: true,
+  data: [
+    brand('brand-1', 'Brand 1', '#111', [
+      [DATE_A, 95],
+      [DATE_B, 90],
+    ]),
+    brand('brand-2', 'Brand 2', '#222', [
+      [DATE_A, 80],
+      [DATE_B, 85],
+    ]),
+  ],
+};
+
+function renderChart(
+  subCharts: readonly [SubChartConfig, ...SubChartConfig[]],
+) {
+  return render(
+    <ThemeProvider theme={testTheme}>
+      <div style={{ width: 800, height: 600 }}>
+        <SynchronizedMetricsChart
+          subCharts={subCharts}
+          isLoading={false}
+          isSuccess={true}
+          isFetching={false}
+          filter={{ timezone: 'UTC', brands: [] }}
+        />
+      </div>
+    </ThemeProvider>,
+  );
+}
+
+describe('<SynchronizedMetricsChart/> controls gating', () => {
+  test('renders both Show Total and Log Scale when absolute multi-brand present', () => {
+    const { getByRole } = renderChart([multiBrandAbsolute]);
+    expect(getByRole('button', { name: 'Show Total line' })).toBeDefined();
+    expect(
+      getByRole('button', { name: 'Toggle logarithmic scale' }),
+    ).toBeDefined();
+  });
+
+  test('hides Show Total when only one brand is in the absolute sub-chart', () => {
+    const { queryByRole, getByRole } = renderChart([singleBrandAbsolute]);
+    expect(queryByRole('button', { name: 'Show Total line' })).toBeNull();
+    // Log Scale is still available because an absolute sub-chart exists.
+    expect(
+      getByRole('button', { name: 'Toggle logarithmic scale' }),
+    ).toBeDefined();
+  });
+
+  test('hides both controls when only percentage sub-charts exist', () => {
+    const { queryByRole } = renderChart([percentageSubChart]);
+    expect(queryByRole('button', { name: 'Show Total line' })).toBeNull();
+    expect(
+      queryByRole('button', { name: 'Toggle logarithmic scale' }),
+    ).toBeNull();
+  });
+
+  test('renders only Show Total + Log Scale when mixing percentage and absolute multi-brand', () => {
+    const { getByRole } = renderChart([percentageSubChart, multiBrandAbsolute]);
+    expect(getByRole('button', { name: 'Show Total line' })).toBeDefined();
+    expect(
+      getByRole('button', { name: 'Toggle logarithmic scale' }),
+    ).toBeDefined();
+  });
+
+  test('toggle aria-pressed flips on click', () => {
+    const { getByRole } = renderChart([multiBrandAbsolute]);
+    const total = getByRole('button', { name: 'Show Total line' });
+
+    expect(total.getAttribute('aria-pressed')).toBe('false');
+    fireEvent.click(total);
+    expect(total.getAttribute('aria-pressed')).toBe('true');
+  });
+});


### PR DESCRIPTION
## Summary
Adds logarithmic view and a "total" line in the multi brands charts, adds legend to single brand charts, adds brand uuid to billable events tables.

## Changes
- feat: extract duplicated CopyableUuid component for UUID display and copy functionality
- feat: replace UUID display logic with CopyableUuid component in SeriesPercentageChartLegend and LogsTable
- feat: add CopyableUuid component for UUID display in BillableEvents tables
- feat: add tests for CopyableUuid component functionality and clipboard interactions
- feat: enhance ConversionOverTimeChart with legend support and copyable UUID options
- feat: enhance SynchronizedMetricsChart with total line and log scale controls
- feat:  include UUID headers and data rows in exportBillableEventsToCsv

## Testing
- Use storybook to test any of the changes 🙃 

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [x] Any dependent changes have been merged and published in upstream projects.
