### PR TITLE
feat: Challenge prompts in metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "9.11.0",
+  "version": "9.11.1-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@verifiedinc-public/shared-ui-elements",
-      "version": "9.11.0",
+      "version": "9.11.1-beta.0",
       "dependencies": {
         "date-fns-tz": "^3.2.0",
         "react-datepicker": "^7.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "9.11.0",
+  "version": "9.11.1-beta.0",
   "description": "A set of UI components, utilities that is shareable with the core apps.",
   "private": false,
   "sideEffects": false,

--- a/src/components/BrandChallengePromptsTooltip/BrandChallengePromptsTooltip.tsx
+++ b/src/components/BrandChallengePromptsTooltip/BrandChallengePromptsTooltip.tsx
@@ -1,0 +1,50 @@
+import { Box, Tooltip, Typography } from '@mui/material';
+import type { ReactElement, ReactNode } from 'react';
+
+import { formatChallengePrompt, type ChallengePrompt } from './format';
+
+export interface BrandChallengePromptsTooltipProps {
+  prompts?: readonly ChallengePrompt[];
+  children: ReactNode;
+}
+
+/**
+ * Wraps `children` with a hover tooltip listing the brand's challenge prompts.
+ * When `prompts` is empty or undefined, renders `children` unwrapped, no
+ * tooltip mounts, so dense surfaces (e.g. billing tables with many rows) pay
+ * zero per-row Popper cost when there's nothing to show.
+ */
+export function BrandChallengePromptsTooltip({
+  prompts,
+  children,
+}: Readonly<BrandChallengePromptsTooltipProps>): ReactElement {
+  if (!prompts || prompts.length === 0) {
+    return <>{children}</>;
+  }
+
+  const body = (
+    <Box>
+      {prompts.map((prompt) => (
+        <Typography
+          key={`${prompt.type}-${prompt.promptForChallenge}`}
+          variant='caption'
+          component='div'
+        >
+          {formatChallengePrompt(prompt)}
+        </Typography>
+      ))}
+    </Box>
+  );
+
+  return (
+    <Tooltip title={body} describeChild placement='top' arrow enterDelay={300}>
+      {/*
+       * `tabIndex={0}` makes the wrapper focusable so the tooltip surfaces on
+       * keyboard navigation. MUI Tooltip requires a focusable child for that;
+       * The span pattern matches MUI's documented guidance for info-only tooltip triggers.
+       */}
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+      <span tabIndex={0}>{children}</span>
+    </Tooltip>
+  );
+}

--- a/src/components/BrandChallengePromptsTooltip/LazyBrandChallengePromptsTooltip.tsx
+++ b/src/components/BrandChallengePromptsTooltip/LazyBrandChallengePromptsTooltip.tsx
@@ -3,7 +3,7 @@ import { useState, type ReactElement, type ReactNode } from 'react';
 import {
   BrandChallengePromptsTooltip,
   type BrandChallengePromptsTooltipProps,
-} from './index';
+} from './BrandChallengePromptsTooltip';
 
 interface LazyProps
   extends Omit<BrandChallengePromptsTooltipProps, 'children'> {

--- a/src/components/BrandChallengePromptsTooltip/LazyBrandChallengePromptsTooltip.tsx
+++ b/src/components/BrandChallengePromptsTooltip/LazyBrandChallengePromptsTooltip.tsx
@@ -1,0 +1,51 @@
+import { useState, type ReactElement, type ReactNode } from 'react';
+
+import {
+  BrandChallengePromptsTooltip,
+  type BrandChallengePromptsTooltipProps,
+} from './index';
+
+interface LazyProps
+  extends Omit<BrandChallengePromptsTooltipProps, 'children'> {
+  children: ReactNode;
+}
+
+/**
+ * Defers mounting the underlying MUI `Tooltip` until the trigger is hovered or
+ * focused. Use in dense surfaces (e.g. tables with 50+ rows) to avoid the
+ * documented Popper-render cost of mounting one Tooltip per row up front
+ * (see MUI #27057, #41144).
+ *
+ * For sparse surfaces (chart legend with <50 entries), prefer
+ * `<BrandChallengePromptsTooltip>` directly — the lazy-mount wrapper has no
+ * benefit and the extra re-render hurts.
+ */
+export function LazyBrandChallengePromptsTooltip({
+  prompts,
+  children,
+}: Readonly<LazyProps>): ReactElement {
+  const [active, setActive] = useState(false);
+
+  if (!active) {
+    return (
+      // The wrapper is a focusable info-only trigger that swaps in the real
+      // Tooltip on first hover/focus. It's not a button (no click action) and
+      // not a link, so the standard a11y interactive-element rules don't fit.
+      // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/no-noninteractive-tabindex
+      <span
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+        tabIndex={0}
+        onMouseEnter={() => setActive(true)}
+        onFocus={() => setActive(true)}
+      >
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <BrandChallengePromptsTooltip prompts={prompts}>
+      {children}
+    </BrandChallengePromptsTooltip>
+  );
+}

--- a/src/components/BrandChallengePromptsTooltip/format.ts
+++ b/src/components/BrandChallengePromptsTooltip/format.ts
@@ -1,0 +1,33 @@
+export type ChallengeInputType = 'birthDate' | 'ssn4' | 'fullName.firstName';
+
+export type ChallengePromptBehavior = 'always' | 'ifNecessary';
+
+export interface ChallengePrompt {
+  type: ChallengeInputType;
+  promptForChallenge: ChallengePromptBehavior;
+}
+
+const INPUT_LABELS: Record<ChallengeInputType, string> = {
+  birthDate: 'Birth Date',
+  ssn4: 'SSN (last 4)',
+  'fullName.firstName': 'First Name',
+};
+
+const BEHAVIOR_LABELS: Record<ChallengePromptBehavior, string> = {
+  always: 'Always',
+  ifNecessary: 'If Necessary',
+};
+
+export function formatChallengeInput(type: ChallengeInputType): string {
+  return INPUT_LABELS[type] ?? type;
+}
+
+export function formatChallengePromptBehavior(
+  behavior: ChallengePromptBehavior,
+): string {
+  return BEHAVIOR_LABELS[behavior] ?? behavior;
+}
+
+export function formatChallengePrompt(prompt: ChallengePrompt): string {
+  return `${formatChallengeInput(prompt.type)}: ${formatChallengePromptBehavior(prompt.promptForChallenge)}`;
+}

--- a/src/components/BrandChallengePromptsTooltip/index.tsx
+++ b/src/components/BrandChallengePromptsTooltip/index.tsx
@@ -1,0 +1,53 @@
+import { Box, Tooltip, Typography } from '@mui/material';
+import type { ReactElement, ReactNode } from 'react';
+
+import { formatChallengePrompt, type ChallengePrompt } from './format';
+
+export type { ChallengePrompt } from './format';
+export { LazyBrandChallengePromptsTooltip } from './LazyBrandChallengePromptsTooltip';
+
+export interface BrandChallengePromptsTooltipProps {
+  prompts?: readonly ChallengePrompt[];
+  children: ReactNode;
+}
+
+/**
+ * Wraps `children` with a hover tooltip listing the brand's challenge prompts.
+ * When `prompts` is empty or undefined, renders `children` unwrapped, no
+ * tooltip mounts, so dense surfaces (e.g. billing tables with many rows) pay
+ * zero per-row Popper cost when there's nothing to show.
+ */
+export function BrandChallengePromptsTooltip({
+  prompts,
+  children,
+}: Readonly<BrandChallengePromptsTooltipProps>): ReactElement {
+  if (!prompts || prompts.length === 0) {
+    return <>{children}</>;
+  }
+
+  const body = (
+    <Box>
+      {prompts.map((prompt) => (
+        <Typography
+          key={`${prompt.type}-${prompt.promptForChallenge}`}
+          variant='caption'
+          component='div'
+        >
+          {formatChallengePrompt(prompt)}
+        </Typography>
+      ))}
+    </Box>
+  );
+
+  return (
+    <Tooltip title={body} describeChild placement='top' arrow enterDelay={300}>
+      {/*
+       * `tabIndex={0}` makes the wrapper focusable so the tooltip surfaces on
+       * keyboard navigation. MUI Tooltip requires a focusable child for that;
+       * The span pattern matches MUI's documented guidance for info-only tooltip triggers.
+       */}
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+      <span tabIndex={0}>{children}</span>
+    </Tooltip>
+  );
+}

--- a/src/components/BrandChallengePromptsTooltip/index.tsx
+++ b/src/components/BrandChallengePromptsTooltip/index.tsx
@@ -1,53 +1,6 @@
-import { Box, Tooltip, Typography } from '@mui/material';
-import type { ReactElement, ReactNode } from 'react';
-
-import { formatChallengePrompt, type ChallengePrompt } from './format';
-
 export type { ChallengePrompt } from './format';
+export {
+  BrandChallengePromptsTooltip,
+  type BrandChallengePromptsTooltipProps,
+} from './BrandChallengePromptsTooltip';
 export { LazyBrandChallengePromptsTooltip } from './LazyBrandChallengePromptsTooltip';
-
-export interface BrandChallengePromptsTooltipProps {
-  prompts?: readonly ChallengePrompt[];
-  children: ReactNode;
-}
-
-/**
- * Wraps `children` with a hover tooltip listing the brand's challenge prompts.
- * When `prompts` is empty or undefined, renders `children` unwrapped, no
- * tooltip mounts, so dense surfaces (e.g. billing tables with many rows) pay
- * zero per-row Popper cost when there's nothing to show.
- */
-export function BrandChallengePromptsTooltip({
-  prompts,
-  children,
-}: Readonly<BrandChallengePromptsTooltipProps>): ReactElement {
-  if (!prompts || prompts.length === 0) {
-    return <>{children}</>;
-  }
-
-  const body = (
-    <Box>
-      {prompts.map((prompt) => (
-        <Typography
-          key={`${prompt.type}-${prompt.promptForChallenge}`}
-          variant='caption'
-          component='div'
-        >
-          {formatChallengePrompt(prompt)}
-        </Typography>
-      ))}
-    </Box>
-  );
-
-  return (
-    <Tooltip title={body} describeChild placement='top' arrow enterDelay={300}>
-      {/*
-       * `tabIndex={0}` makes the wrapper focusable so the tooltip surfaces on
-       * keyboard navigation. MUI Tooltip requires a focusable child for that;
-       * The span pattern matches MUI's documented guidance for info-only tooltip triggers.
-       */}
-      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
-      <span tabIndex={0}>{children}</span>
-    </Tooltip>
-  );
-}

--- a/src/components/BrandFilterInput/types.ts
+++ b/src/components/BrandFilterInput/types.ts
@@ -10,7 +10,7 @@ export interface Brands {
   isLiveBrand?: boolean;
   isApproved?: boolean;
   additionalData?: any;
-  challengePrompts?: readonly ChallengePrompt[];
+  inputChallengePrompts?: readonly ChallengePrompt[];
 }
 
 export type BrandFilter = {

--- a/src/components/BrandFilterInput/types.ts
+++ b/src/components/BrandFilterInput/types.ts
@@ -1,3 +1,5 @@
+import type { ChallengePrompt } from '../BrandChallengePromptsTooltip';
+
 export interface Brands {
   brandUuid: string;
   brandName: string;
@@ -8,6 +10,7 @@ export interface Brands {
   isLiveBrand?: boolean;
   isApproved?: boolean;
   additionalData?: any;
+  challengePrompts?: readonly ChallengePrompt[];
 }
 
 export type BrandFilter = {

--- a/src/components/chart/BillableEventsTable/BillableEventsTable.tsx
+++ b/src/components/chart/BillableEventsTable/BillableEventsTable.tsx
@@ -21,6 +21,7 @@ import {
 } from './BillableEventsTable.types';
 import { useBillableSort } from './useBillableSort.hook';
 import { CopyableUuid } from '../../CopyableUuid';
+import { LazyBrandChallengePromptsTooltip } from '../../BrandChallengePromptsTooltip';
 import { white } from '../../../styles';
 
 const DIRECT_KEYS = ['brand', 'integrationType'];
@@ -127,7 +128,13 @@ export const BillableEventsTable: React.FC<BillableEventsTableProps> = ({
         <TableBody>
           {sortedData.map((row: BillableEventsTableRow) => (
             <TableRow key={row.brandUuid}>
-              <TableCell>{row.brand}</TableCell>
+              <TableCell>
+                <LazyBrandChallengePromptsTooltip
+                  prompts={row.challengePrompts}
+                >
+                  {row.brand}
+                </LazyBrandChallengePromptsTooltip>
+              </TableCell>
               <TableCell>
                 <CopyableUuid
                   uuid={row.brandUuid}

--- a/src/components/chart/BillableEventsTable/BillableEventsTable.tsx
+++ b/src/components/chart/BillableEventsTable/BillableEventsTable.tsx
@@ -130,7 +130,7 @@ export const BillableEventsTable: React.FC<BillableEventsTableProps> = ({
             <TableRow key={row.brandUuid}>
               <TableCell>
                 <LazyBrandChallengePromptsTooltip
-                  prompts={row.challengePrompts}
+                  prompts={row.inputChallengePrompts}
                 >
                   {row.brand}
                 </LazyBrandChallengePromptsTooltip>

--- a/src/components/chart/BillableEventsTable/BillableEventsTable.types.ts
+++ b/src/components/chart/BillableEventsTable/BillableEventsTable.types.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ChartData } from '../BillableEventsProductTable';
+import type { ChallengePrompt } from '../../BrandChallengePromptsTooltip';
 
 export enum BillableProduct {
   TEXT_TO_SIGNUP = 'TEXT_TO_SIGNUP',
@@ -88,6 +89,7 @@ export type BillableEventsTableRow = {
   integrationType: string;
   metrics: Record<string, number>;
   raw: ChartData;
+  challengePrompts?: readonly ChallengePrompt[];
 };
 
 export type BillableEventsTableProps = {

--- a/src/components/chart/BillableEventsTable/BillableEventsTable.types.ts
+++ b/src/components/chart/BillableEventsTable/BillableEventsTable.types.ts
@@ -89,7 +89,7 @@ export type BillableEventsTableRow = {
   integrationType: string;
   metrics: Record<string, number>;
   raw: ChartData;
-  challengePrompts?: readonly ChallengePrompt[];
+  inputChallengePrompts?: readonly ChallengePrompt[];
 };
 
 export type BillableEventsTableProps = {

--- a/src/components/chart/BillableEventsTable/BillableEventsTableDataMapper.ts
+++ b/src/components/chart/BillableEventsTable/BillableEventsTableDataMapper.ts
@@ -3,6 +3,7 @@ import {
   BillableProduct,
   type BillableEventsTableRow,
 } from './BillableEventsTable.types';
+import type { ChallengePrompt } from '../../BrandChallengePromptsTooltip';
 
 /**
  * Maps raw or pre-mapped integration type values to display labels.
@@ -26,6 +27,8 @@ type Brand = {
   brandUuid: string;
   brandName: string;
   integrationType: string;
+  challengePrompts?: readonly ChallengePrompt[];
+  inputChallengePrompts?: readonly ChallengePrompt[];
 };
 
 type ChartData = {
@@ -82,16 +85,18 @@ export const mapBillableEventsTableData = ({
   }
 
   return Array.from(brandsWithData.entries())
-    .map(([brandUuid, raw]) => {
+    .map(([brandUuid, raw]): BillableEventsTableRow | null => {
       const brand = brands.find((b) => b.brandUuid === brandUuid);
       if (!brand) return null;
 
+      const prompts = brand.challengePrompts ?? brand.inputChallengePrompts;
       return {
         brandUuid,
         brand: brand.brandName,
         integrationType: formatIntegrationType(brand.integrationType),
         metrics: brandMetrics.get(brandUuid) ?? {},
         raw,
+        ...(prompts ? { challengePrompts: prompts } : {}),
       };
     })
     .filter((row): row is BillableEventsTableRow => row !== null);

--- a/src/components/chart/BillableEventsTable/BillableEventsTableDataMapper.ts
+++ b/src/components/chart/BillableEventsTable/BillableEventsTableDataMapper.ts
@@ -27,7 +27,6 @@ type Brand = {
   brandUuid: string;
   brandName: string;
   integrationType: string;
-  challengePrompts?: readonly ChallengePrompt[];
   inputChallengePrompts?: readonly ChallengePrompt[];
 };
 
@@ -89,14 +88,15 @@ export const mapBillableEventsTableData = ({
       const brand = brands.find((b) => b.brandUuid === brandUuid);
       if (!brand) return null;
 
-      const prompts = brand.challengePrompts ?? brand.inputChallengePrompts;
       return {
         brandUuid,
         brand: brand.brandName,
         integrationType: formatIntegrationType(brand.integrationType),
         metrics: brandMetrics.get(brandUuid) ?? {},
         raw,
-        ...(prompts ? { challengePrompts: prompts } : {}),
+        ...(brand.inputChallengePrompts
+          ? { inputChallengePrompts: brand.inputChallengePrompts }
+          : {}),
       };
     })
     .filter((row): row is BillableEventsTableRow => row !== null);

--- a/src/components/chart/BillableEventsTable/BillableEventsTableDataMapper.ts
+++ b/src/components/chart/BillableEventsTable/BillableEventsTableDataMapper.ts
@@ -94,7 +94,7 @@ export const mapBillableEventsTableData = ({
         integrationType: formatIntegrationType(brand.integrationType),
         metrics: brandMetrics.get(brandUuid) ?? {},
         raw,
-        ...(brand.inputChallengePrompts
+        ...(brand.inputChallengePrompts?.length
           ? { inputChallengePrompts: brand.inputChallengePrompts }
           : {}),
       };

--- a/src/components/chart/ConversionOverTimeChart/index.tsx
+++ b/src/components/chart/ConversionOverTimeChart/index.tsx
@@ -15,6 +15,7 @@ import { useStyle } from '../styles';
 import { formatDateMMYY, formatExtendedDate } from '../../../utils/date';
 import { DEFAULT_TIMEZONE } from '../../form/TimezoneInput/timezones';
 import type { BrandFilter } from '../../BrandFilterInput';
+import type { ChallengePrompt } from '../../BrandChallengePromptsTooltip';
 
 export type { AreaSeriesChartData } from '../AreaChart';
 
@@ -75,6 +76,7 @@ export interface ConversionOverTimeChartLegendBrand {
   dataKey?: string;
   brandName?: string;
   integrationType?: string;
+  challengePrompts?: readonly ChallengePrompt[];
 }
 
 export interface ConversionOverTimeChartProps {
@@ -261,6 +263,7 @@ export function ConversionOverTimeChart({
               dataKey: legendBrand.dataKey ?? legendBrand.uuid,
               brandName: legendBrand.brandName,
               integrationType: legendBrand.integrationType,
+              challengePrompts: legendBrand.challengePrompts,
             },
           ]}
           showUuid={showLegendUuid}

--- a/src/components/chart/ConversionOverTimeChart/index.tsx
+++ b/src/components/chart/ConversionOverTimeChart/index.tsx
@@ -76,7 +76,7 @@ export interface ConversionOverTimeChartLegendBrand {
   dataKey?: string;
   brandName?: string;
   integrationType?: string;
-  challengePrompts?: readonly ChallengePrompt[];
+  inputChallengePrompts?: readonly ChallengePrompt[];
 }
 
 export interface ConversionOverTimeChartProps {
@@ -100,6 +100,11 @@ export interface ConversionOverTimeChartProps {
   legendBrand?: ConversionOverTimeChartLegendBrand;
   /** Whether the legend displays the copyable UUID. Defaults to true. */
   showLegendUuid?: boolean;
+  /**
+   * Forwarded to the legend. When true, hovering the legend entry reveals
+   * the brand's `inputChallengePrompts` as a tooltip. Default false.
+   */
+  showChallengePromptsTooltip?: boolean;
 }
 
 export function ConversionOverTimeChart({
@@ -115,14 +120,16 @@ export function ConversionOverTimeChart({
   sx,
   legendBrand,
   showLegendUuid = true,
+  showChallengePromptsTooltip,
 }: Readonly<ConversionOverTimeChartProps>): React.ReactNode {
   const style = useStyle();
   const timezone = filter.timezone ?? DEFAULT_TIMEZONE;
   const [mode, setMode] = useState<ViewMode>('absolute');
 
   const resolved =
-    chartData !== undefined
-      ? isLoading
+    chartData === undefined
+      ? { series: series ?? [], data: data ?? [] }
+      : isLoading
         ? {
             series: [] as AreaSeriesChartData[],
             data: [] as Array<Record<string, number | string>>,
@@ -131,8 +138,7 @@ export function ConversionOverTimeChart({
             brands: filter.brands,
             data: chartData,
             seriesConfig: seriesConfig ?? [],
-          })
-      : { series: series ?? [], data: data ?? [] };
+          });
 
   if (!resolved.data.length && isLoading) {
     return <LoadingChartSection />;
@@ -263,10 +269,11 @@ export function ConversionOverTimeChart({
               dataKey: legendBrand.dataKey ?? legendBrand.uuid,
               brandName: legendBrand.brandName,
               integrationType: legendBrand.integrationType,
-              challengePrompts: legendBrand.challengePrompts,
+              inputChallengePrompts: legendBrand.inputChallengePrompts,
             },
           ]}
           showUuid={showLegendUuid}
+          showChallengePromptsTooltip={showChallengePromptsTooltip}
         />
       )}
     </Stack>

--- a/src/components/chart/SeriesChart/SeriesChart.map.ts
+++ b/src/components/chart/SeriesChart/SeriesChart.map.ts
@@ -15,7 +15,7 @@ interface TimeSeriesChartData {
   name: string;
   color: string;
   chartData: TimeSeriesDataPoint[];
-  challengePrompts?: readonly ChallengePrompt[];
+  inputChallengePrompts?: readonly ChallengePrompt[];
 }
 
 export interface MapSeriesTimeSeriesDataOptions {
@@ -57,7 +57,7 @@ export function mapSeriesTimeSeriesData(
       brandColor?: string;
       brandIntegrationType: string;
       chartData: TimeSeriesDataPoint[];
-      challengePrompts?: readonly ChallengePrompt[];
+      inputChallengePrompts?: readonly ChallengePrompt[];
     }
   >();
 
@@ -104,7 +104,7 @@ export function mapSeriesTimeSeriesData(
           brandColor: colorMap.get(brand.brandUuid),
           brandIntegrationType: brand.integrationType,
           chartData: consolidatedChartData,
-          challengePrompts: brand.challengePrompts,
+          inputChallengePrompts: brand.inputChallengePrompts,
         });
       } else {
         keywordDataMap.set(identifier, {
@@ -114,7 +114,7 @@ export function mapSeriesTimeSeriesData(
           brandColor: colorMap.get(brand.brandUuid),
           brandIntegrationType: brand.integrationType,
           chartData,
-          challengePrompts: brand.challengePrompts,
+          inputChallengePrompts: brand.inputChallengePrompts,
         });
       }
     });
@@ -155,7 +155,7 @@ export function mapSeriesTimeSeriesData(
       brandColor,
       brandIntegrationType,
       chartData,
-      challengePrompts,
+      inputChallengePrompts,
     }) => ({
       uuid: keyword ?? brandUuid, // Use keyword as uuid since we're grouping by keyword, fallback to brandUuid
       name: keyword ?? brandName, // Display keyword as the name, fallback to brandName
@@ -164,7 +164,7 @@ export function mapSeriesTimeSeriesData(
       chartData,
       brandUuid: keyword ? brandUuid : undefined,
       brandName: keyword ? brandName : undefined,
-      challengePrompts,
+      inputChallengePrompts,
     }),
   );
 

--- a/src/components/chart/SeriesChart/SeriesChart.map.ts
+++ b/src/components/chart/SeriesChart/SeriesChart.map.ts
@@ -3,6 +3,7 @@ import sortBy from 'lodash/sortBy';
 import { stringToHashedColor } from '../../../utils/uuidColor';
 
 import { BrandFilter } from '../../BrandFilterInput';
+import type { ChallengePrompt } from '../../BrandChallengePromptsTooltip';
 
 interface TimeSeriesDataPoint {
   date: number;
@@ -14,6 +15,7 @@ interface TimeSeriesChartData {
   name: string;
   color: string;
   chartData: TimeSeriesDataPoint[];
+  challengePrompts?: readonly ChallengePrompt[];
 }
 
 export interface MapSeriesTimeSeriesDataOptions {
@@ -55,6 +57,7 @@ export function mapSeriesTimeSeriesData(
       brandColor?: string;
       brandIntegrationType: string;
       chartData: TimeSeriesDataPoint[];
+      challengePrompts?: readonly ChallengePrompt[];
     }
   >();
 
@@ -101,6 +104,7 @@ export function mapSeriesTimeSeriesData(
           brandColor: colorMap.get(brand.brandUuid),
           brandIntegrationType: brand.integrationType,
           chartData: consolidatedChartData,
+          challengePrompts: brand.challengePrompts,
         });
       } else {
         keywordDataMap.set(identifier, {
@@ -110,6 +114,7 @@ export function mapSeriesTimeSeriesData(
           brandColor: colorMap.get(brand.brandUuid),
           brandIntegrationType: brand.integrationType,
           chartData,
+          challengePrompts: brand.challengePrompts,
         });
       }
     });
@@ -150,6 +155,7 @@ export function mapSeriesTimeSeriesData(
       brandColor,
       brandIntegrationType,
       chartData,
+      challengePrompts,
     }) => ({
       uuid: keyword ?? brandUuid, // Use keyword as uuid since we're grouping by keyword, fallback to brandUuid
       name: keyword ?? brandName, // Display keyword as the name, fallback to brandName
@@ -158,6 +164,7 @@ export function mapSeriesTimeSeriesData(
       chartData,
       brandUuid: keyword ? brandUuid : undefined,
       brandName: keyword ? brandName : undefined,
+      challengePrompts,
     }),
   );
 

--- a/src/components/chart/SeriesChart/index.tsx
+++ b/src/components/chart/SeriesChart/index.tsx
@@ -13,9 +13,9 @@ import {
 } from 'recharts';
 
 import { formatDateMMYY, formatExtendedDate } from '../../../utils/date';
-
 import { SeriesChartLegend } from '../SeriesChartLegend';
 import { DEFAULT_TIMEZONE } from '../../form/TimezoneInput/timezones';
+import type { ChallengePrompt } from '../../BrandChallengePromptsTooltip';
 
 interface ChartDataPoint {
   date: number;
@@ -30,6 +30,7 @@ export interface SeriesChartData {
   chartData: ChartDataPoint[];
   brandUuid?: string;
   brandName?: string;
+  challengePrompts?: readonly ChallengePrompt[];
 }
 
 interface SeriesChartProps {
@@ -41,7 +42,7 @@ interface SeriesChartProps {
   showLegend?: boolean;
 }
 
-export function SeriesChart(props: SeriesChartProps): ReactElement {
+export function SeriesChart(props: Readonly<SeriesChartProps>): ReactElement {
   const theme = useTheme();
 
   // Default to UTC if no timezone is provided

--- a/src/components/chart/SeriesChart/index.tsx
+++ b/src/components/chart/SeriesChart/index.tsx
@@ -30,7 +30,7 @@ export interface SeriesChartData {
   chartData: ChartDataPoint[];
   brandUuid?: string;
   brandName?: string;
-  challengePrompts?: readonly ChallengePrompt[];
+  inputChallengePrompts?: readonly ChallengePrompt[];
 }
 
 interface SeriesChartProps {

--- a/src/components/chart/SeriesPercentageChartLegend/index.tsx
+++ b/src/components/chart/SeriesPercentageChartLegend/index.tsx
@@ -30,7 +30,6 @@ function EntryBlock({
 }>): ReactElement {
   return (
     <MotionStack
-      component='li'
       direction='row'
       spacing={1}
       sx={{
@@ -93,6 +92,8 @@ export function SeriesPercentageChartLegend(
       gap={2}
       sx={{
         mt: 2,
+        pl: 0,
+        listStyle: 'none',
         justifyContent: 'flex-start',
         alignItem: 'center',
         flexWrap: 'wrap',
@@ -100,7 +101,7 @@ export function SeriesPercentageChartLegend(
     >
       <AnimatePresence>
         {payload?.map((entry) => (
-          <Grid2 key={`item-${entry.uuid}-${entry.value}`}>
+          <Grid2 key={`item-${entry.uuid}-${entry.value}`} component='li'>
             {showChallengePromptsTooltip ? (
               <BrandChallengePromptsTooltip
                 prompts={entry.inputChallengePrompts}

--- a/src/components/chart/SeriesPercentageChartLegend/index.tsx
+++ b/src/components/chart/SeriesPercentageChartLegend/index.tsx
@@ -6,6 +6,10 @@ import { type LegendProps } from 'recharts';
 
 import { MotionStack } from '../../animation';
 import { CopyableUuid } from '../../CopyableUuid';
+import {
+  BrandChallengePromptsTooltip,
+  type ChallengePrompt,
+} from '../../BrandChallengePromptsTooltip';
 
 type CustomPayload = {
   uuid: string;
@@ -14,6 +18,7 @@ type CustomPayload = {
   dataKey: string;
   integrationType?: string;
   brandName?: string;
+  challengePrompts?: readonly ChallengePrompt[];
 };
 
 function EntryBlock({
@@ -95,7 +100,9 @@ export function SeriesPercentageChartLegend(
       <AnimatePresence>
         {payload?.map((entry) => (
           <Grid2 key={`item-${entry.uuid}-${entry.value}`}>
-            <EntryBlock entry={entry} showUuid={props.showUuid} />
+            <BrandChallengePromptsTooltip prompts={entry.challengePrompts}>
+              <EntryBlock entry={entry} showUuid={props.showUuid} />
+            </BrandChallengePromptsTooltip>
           </Grid2>
         ))}
       </AnimatePresence>

--- a/src/components/chart/SeriesPercentageChartLegend/index.tsx
+++ b/src/components/chart/SeriesPercentageChartLegend/index.tsx
@@ -18,7 +18,7 @@ type CustomPayload = {
   dataKey: string;
   integrationType?: string;
   brandName?: string;
-  challengePrompts?: readonly ChallengePrompt[];
+  inputChallengePrompts?: readonly ChallengePrompt[];
 };
 
 function EntryBlock({
@@ -77,12 +77,13 @@ interface SeriesPercentageChartLegendProps
   extends Omit<LegendProps, 'payload'> {
   showUuid?: boolean;
   payload?: CustomPayload[];
+  showChallengePromptsTooltip?: boolean;
 }
 
 export function SeriesPercentageChartLegend(
   props: Readonly<SeriesPercentageChartLegendProps>,
 ): ReactElement {
-  const { payload } = props;
+  const { payload, showChallengePromptsTooltip = false } = props;
 
   return (
     <Grid2
@@ -100,9 +101,15 @@ export function SeriesPercentageChartLegend(
       <AnimatePresence>
         {payload?.map((entry) => (
           <Grid2 key={`item-${entry.uuid}-${entry.value}`}>
-            <BrandChallengePromptsTooltip prompts={entry.challengePrompts}>
+            {showChallengePromptsTooltip ? (
+              <BrandChallengePromptsTooltip
+                prompts={entry.inputChallengePrompts}
+              >
+                <EntryBlock entry={entry} showUuid={props.showUuid} />
+              </BrandChallengePromptsTooltip>
+            ) : (
               <EntryBlock entry={entry} showUuid={props.showUuid} />
-            </BrandChallengePromptsTooltip>
+            )}
           </Grid2>
         ))}
       </AnimatePresence>

--- a/src/components/chart/SynchronizedMetricsChart/SynchronizedMetricsChart.tsx
+++ b/src/components/chart/SynchronizedMetricsChart/SynchronizedMetricsChart.tsx
@@ -196,6 +196,7 @@ export function SynchronizedMetricsChart({
   isFetching,
   filter,
   sx,
+  showChallengePromptsTooltip,
 }: Readonly<SynchronizedMetricsChartProps>): React.ReactNode {
   const timezone = filter.timezone ?? DEFAULT_TIMEZONE;
   const [showTotal, setShowTotal] = useState(false);
@@ -239,7 +240,7 @@ export function SynchronizedMetricsChart({
         dataKey: b.uuid,
         integrationType: b.description ?? undefined,
         brandName: b.brandName,
-        challengePrompts: b.challengePrompts,
+        inputChallengePrompts: b.inputChallengePrompts,
       })),
     [resolvedSubCharts],
   );
@@ -306,7 +307,10 @@ export function SynchronizedMetricsChart({
             yAxisDomain={sc.yAxisDomain}
           />
         ))}
-        <SeriesPercentageChartLegend payload={legendPayload} />
+        <SeriesPercentageChartLegend
+          payload={legendPayload}
+          showChallengePromptsTooltip={showChallengePromptsTooltip}
+        />
       </Stack>
     </Stack>
   );

--- a/src/components/chart/SynchronizedMetricsChart/SynchronizedMetricsChart.tsx
+++ b/src/components/chart/SynchronizedMetricsChart/SynchronizedMetricsChart.tsx
@@ -239,6 +239,7 @@ export function SynchronizedMetricsChart({
         dataKey: b.uuid,
         integrationType: b.description ?? undefined,
         brandName: b.brandName,
+        challengePrompts: b.challengePrompts,
       })),
     [resolvedSubCharts],
   );

--- a/src/components/chart/SynchronizedMetricsChart/SynchronizedMetricsChart.types.ts
+++ b/src/components/chart/SynchronizedMetricsChart/SynchronizedMetricsChart.types.ts
@@ -45,6 +45,7 @@ type SynchronizedMetricsChartBaseProps = {
     brands: BrandFilter[];
   };
   sx?: SxProps;
+  showChallengePromptsTooltip?: boolean;
 };
 
 export type SynchronizedMetricsChartProps = SynchronizedMetricsChartBaseProps &

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -23,3 +23,4 @@ export * from './UI';
 export * from './text-to-signup';
 export * from './logs';
 export * from './CopyableUuid';
+export * from './BrandChallengePromptsTooltip';

--- a/src/stories/components/BrandChallengePromptsTooltip.stories.tsx
+++ b/src/stories/components/BrandChallengePromptsTooltip.stories.tsx
@@ -1,0 +1,105 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Stack, Typography } from '@mui/material';
+
+import {
+  BrandChallengePromptsTooltip,
+  LazyBrandChallengePromptsTooltip,
+  type ChallengePrompt,
+} from '../../components/BrandChallengePromptsTooltip';
+
+const ALL_PROMPTS: ChallengePrompt[] = [
+  { type: 'birthDate', promptForChallenge: 'always' },
+  { type: 'ssn4', promptForChallenge: 'ifNecessary' },
+  { type: 'fullName.firstName', promptForChallenge: 'always' },
+];
+
+const SINGLE_PROMPT: ChallengePrompt[] = [
+  { type: 'ssn4', promptForChallenge: 'always' },
+];
+
+const meta: Meta<typeof BrandChallengePromptsTooltip> = {
+  title: 'Components/BrandChallengePromptsTooltip',
+  component: BrandChallengePromptsTooltip,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Wraps a child element with a hover tooltip listing the brand challenge prompts. Renders children unwrapped (no tooltip mounted) when prompts are empty or undefined — useful for dense surfaces like billing tables where most rows have no prompts.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof BrandChallengePromptsTooltip>;
+
+export const AllPrompts: Story = {
+  args: {
+    prompts: ALL_PROMPTS,
+    children: <Typography>Hover me — Acme Corp</Typography>,
+  },
+};
+
+export const SinglePrompt: Story = {
+  args: {
+    prompts: SINGLE_PROMPT,
+    children: <Typography>Hover me — Pied Piper</Typography>,
+  },
+};
+
+export const EmptyArrayNoTooltip: Story = {
+  args: {
+    prompts: [],
+    children: (
+      <Typography>
+        Hover me — no tooltip mounts (children render unwrapped)
+      </Typography>
+    ),
+  },
+};
+
+export const UndefinedNoTooltip: Story = {
+  args: {
+    prompts: undefined,
+    children: (
+      <Typography>
+        Hover me — no tooltip mounts (children render unwrapped)
+      </Typography>
+    ),
+  },
+};
+
+export const SideBySideComparison: Story = {
+  render: () => (
+    <Stack spacing={3} alignItems='flex-start'>
+      <BrandChallengePromptsTooltip prompts={ALL_PROMPTS}>
+        <Typography>Brand A — three prompts</Typography>
+      </BrandChallengePromptsTooltip>
+      <BrandChallengePromptsTooltip prompts={SINGLE_PROMPT}>
+        <Typography>Brand B — one prompt</Typography>
+      </BrandChallengePromptsTooltip>
+      <BrandChallengePromptsTooltip prompts={[]}>
+        <Typography>Brand C — no prompts (silent on hover)</Typography>
+      </BrandChallengePromptsTooltip>
+    </Stack>
+  ),
+};
+
+export const LazyVariantForDenseTables: Story = {
+  render: () => (
+    <Stack spacing={1} alignItems='flex-start'>
+      <Typography variant='caption' color='text.secondary'>
+        Used inside the billable events table — Tooltip mounts only after the
+        first hover/focus, so initial render of 100+ rows stays cheap.
+      </Typography>
+      <LazyBrandChallengePromptsTooltip prompts={ALL_PROMPTS}>
+        Acme Corp
+      </LazyBrandChallengePromptsTooltip>
+      <LazyBrandChallengePromptsTooltip prompts={[]}>
+        Pied Piper (no prompts — never mounts a Tooltip)
+      </LazyBrandChallengePromptsTooltip>
+    </Stack>
+  ),
+};

--- a/src/stories/components/chart/BillableEventsTable.stories.tsx
+++ b/src/stories/components/chart/BillableEventsTable.stories.tsx
@@ -7,6 +7,7 @@ import {
   exportBillableEventsToCsv,
 } from '../../../components/chart/BillableEventsTable';
 import { BillableEventColumn } from '../../../components/chart/BillableEventsTable/BillableEventsTable.types';
+import type { ChallengePrompt } from '../../../components/BrandChallengePromptsTooltip';
 
 const meta: Meta<typeof BillableEventsTable> = {
   title: 'Components/chart/BillableEventsTable',
@@ -179,6 +180,40 @@ export const WithTopLevelColumns: Story = {
           size='small'
         />
       ),
+    },
+  },
+};
+
+const HOOLI_PROMPTS: ChallengePrompt[] = [
+  { type: 'birthDate', promptForChallenge: 'always' },
+  { type: 'ssn4', promptForChallenge: 'ifNecessary' },
+];
+
+const AVIATO_PROMPTS: ChallengePrompt[] = [
+  { type: 'fullName.firstName', promptForChallenge: 'always' },
+];
+
+const dataWithPrompts: BillableEventsTableRow[] = [
+  { ...mockData[0], challengePrompts: HOOLI_PROMPTS },
+  // Pied Piper intentionally has no prompts — hovering its brand cell renders
+  // the cell directly, no tooltip mounts.
+  mockData[1],
+  { ...mockData[2], challengePrompts: AVIATO_PROMPTS },
+];
+
+export const WithChallengePrompts: Story = {
+  args: {
+    data: dataWithPrompts,
+    isLoading: false,
+    isFetching: false,
+    visibleProducts: [BillableProduct.ONE_CLICK_SIGNUP],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Hover the Brand Name cell. Hooli Health and Aviato show their challenge prompts; Pied Piper has none configured, so its cell renders without a tooltip.',
+      },
     },
   },
 };

--- a/src/stories/components/chart/BillableEventsTable.stories.tsx
+++ b/src/stories/components/chart/BillableEventsTable.stories.tsx
@@ -194,11 +194,11 @@ const AVIATO_PROMPTS: ChallengePrompt[] = [
 ];
 
 const dataWithPrompts: BillableEventsTableRow[] = [
-  { ...mockData[0], challengePrompts: HOOLI_PROMPTS },
+  { ...mockData[0], inputChallengePrompts: HOOLI_PROMPTS },
   // Pied Piper intentionally has no prompts — hovering its brand cell renders
   // the cell directly, no tooltip mounts.
   mockData[1],
-  { ...mockData[2], challengePrompts: AVIATO_PROMPTS },
+  { ...mockData[2], inputChallengePrompts: AVIATO_PROMPTS },
 ];
 
 export const WithChallengePrompts: Story = {

--- a/src/stories/components/chart/SeriesPercentageChartLegend.stories.tsx
+++ b/src/stories/components/chart/SeriesPercentageChartLegend.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { SeriesPercentageChartLegend } from '../../../components/chart/SeriesPercentageChartLegend';
+import type { ChallengePrompt } from '../../../components/BrandChallengePromptsTooltip';
+
+const ACME_PROMPTS: ChallengePrompt[] = [
+  { type: 'birthDate', promptForChallenge: 'always' },
+  { type: 'ssn4', promptForChallenge: 'ifNecessary' },
+  { type: 'fullName.firstName', promptForChallenge: 'always' },
+];
+
+const PIED_PIPER_PROMPTS: ChallengePrompt[] = [
+  { type: 'ssn4', promptForChallenge: 'always' },
+];
+
+const meta: Meta<typeof SeriesPercentageChartLegend> = {
+  title: 'Components/chart/SeriesPercentageChartLegend',
+  component: SeriesPercentageChartLegend,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Renders a multi-brand chart legend. Each entry can carry an optional `challengePrompts` payload — when present, hovering the entry reveals a tooltip listing the brand`s challenge prompt configuration.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof SeriesPercentageChartLegend>;
+
+export const WithChallengePrompts: Story = {
+  args: {
+    showUuid: true,
+    payload: [
+      {
+        uuid: 'c44d24d0-8cef-4fcc-ad37-1fe154d97e57',
+        value: 'Acme Corp',
+        color: '#1976d2',
+        dataKey: 'acme',
+        integrationType: 'SDK',
+        brandName: 'Acme Corp',
+        challengePrompts: ACME_PROMPTS,
+      },
+      {
+        uuid: '42f12a06-47a7-46bf-901b-e4a8227266d0',
+        value: 'Pied Piper',
+        color: '#388e3c',
+        dataKey: 'pied-piper',
+        integrationType: 'API',
+        brandName: 'Pied Piper',
+        challengePrompts: PIED_PIPER_PROMPTS,
+      },
+      {
+        uuid: '8a9b7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d',
+        value: 'Aviato',
+        color: '#d32f2f',
+        dataKey: 'aviato',
+        integrationType: 'Semi-Hosted',
+        brandName: 'Aviato',
+        // No challengePrompts — hovering this entry shows nothing.
+      },
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Hover each legend entry. Acme and Pied Piper show their challenge prompts; Aviato has none configured, so its entry renders without a tooltip.',
+      },
+    },
+  },
+};
+
+export const NoPromptsAnywhere: Story = {
+  args: {
+    showUuid: true,
+    payload: [
+      {
+        uuid: 'c44d24d0-8cef-4fcc-ad37-1fe154d97e57',
+        value: 'Acme Corp',
+        color: '#1976d2',
+        dataKey: 'acme',
+        integrationType: 'SDK',
+        brandName: 'Acme Corp',
+      },
+      {
+        uuid: '42f12a06-47a7-46bf-901b-e4a8227266d0',
+        value: 'Pied Piper',
+        color: '#388e3c',
+        dataKey: 'pied-piper',
+        integrationType: 'API',
+        brandName: 'Pied Piper',
+      },
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Baseline: legend without any challenge prompts (e.g. Health, Verify, TTS charts). Hover does nothing.',
+      },
+    },
+  },
+};

--- a/src/stories/components/chart/SeriesPercentageChartLegend.stories.tsx
+++ b/src/stories/components/chart/SeriesPercentageChartLegend.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta<typeof SeriesPercentageChartLegend> = {
     docs: {
       description: {
         component:
-          'Renders a multi-brand chart legend. Each entry can carry an optional `inputChallengePrompts` payload — when present, hovering the entry reveals a tooltip listing the brand`s challenge prompt configuration.',
+          "Renders a multi-brand chart legend. Each entry can carry an optional `inputChallengePrompts` payload — when present, hovering the entry reveals a tooltip listing the brand's challenge prompt configuration.",
       },
     },
   },

--- a/src/stories/components/chart/SeriesPercentageChartLegend.stories.tsx
+++ b/src/stories/components/chart/SeriesPercentageChartLegend.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta<typeof SeriesPercentageChartLegend> = {
     docs: {
       description: {
         component:
-          'Renders a multi-brand chart legend. Each entry can carry an optional `challengePrompts` payload — when present, hovering the entry reveals a tooltip listing the brand`s challenge prompt configuration.',
+          'Renders a multi-brand chart legend. Each entry can carry an optional `inputChallengePrompts` payload — when present, hovering the entry reveals a tooltip listing the brand`s challenge prompt configuration.',
       },
     },
   },
@@ -34,6 +34,7 @@ type Story = StoryObj<typeof SeriesPercentageChartLegend>;
 export const WithChallengePrompts: Story = {
   args: {
     showUuid: true,
+    showChallengePromptsTooltip: true,
     payload: [
       {
         uuid: 'c44d24d0-8cef-4fcc-ad37-1fe154d97e57',
@@ -42,7 +43,7 @@ export const WithChallengePrompts: Story = {
         dataKey: 'acme',
         integrationType: 'SDK',
         brandName: 'Acme Corp',
-        challengePrompts: ACME_PROMPTS,
+        inputChallengePrompts: ACME_PROMPTS,
       },
       {
         uuid: '42f12a06-47a7-46bf-901b-e4a8227266d0',
@@ -51,7 +52,7 @@ export const WithChallengePrompts: Story = {
         dataKey: 'pied-piper',
         integrationType: 'API',
         brandName: 'Pied Piper',
-        challengePrompts: PIED_PIPER_PROMPTS,
+        inputChallengePrompts: PIED_PIPER_PROMPTS,
       },
       {
         uuid: '8a9b7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d',
@@ -60,7 +61,7 @@ export const WithChallengePrompts: Story = {
         dataKey: 'aviato',
         integrationType: 'Semi-Hosted',
         brandName: 'Aviato',
-        // No challengePrompts — hovering this entry shows nothing.
+        // No inputChallengePrompts — hovering this entry shows nothing.
       },
     ],
   },

--- a/tests/components/BrandChallengePromptsTooltip.test.tsx
+++ b/tests/components/BrandChallengePromptsTooltip.test.tsx
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+
+import {
+  BrandChallengePromptsTooltip,
+  LazyBrandChallengePromptsTooltip,
+  type ChallengePrompt,
+} from '../../src/components/BrandChallengePromptsTooltip';
+
+const PROMPTS: ChallengePrompt[] = [
+  { type: 'birthDate', promptForChallenge: 'always' },
+  { type: 'ssn4', promptForChallenge: 'ifNecessary' },
+];
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('<BrandChallengePromptsTooltip/>', () => {
+  test('renders prompts on hover', async () => {
+    const { getByText, findByRole } = render(
+      <BrandChallengePromptsTooltip prompts={PROMPTS}>
+        <span>Acme</span>
+      </BrandChallengePromptsTooltip>,
+    );
+
+    fireEvent.mouseOver(getByText('Acme'));
+
+    const tooltip = await findByRole('tooltip');
+    expect(tooltip.textContent).toContain('Birth Date: Always');
+    expect(tooltip.textContent).toContain('SSN (last 4): If Necessary');
+  });
+
+  test('trigger is keyboard-focusable', () => {
+    // Real focus-visible activation is browser-only; jsdom can't simulate it.
+    // Assert the structural prerequisite: tabIndex=0 on the wrapping span.
+    const { getByText } = render(
+      <BrandChallengePromptsTooltip prompts={PROMPTS}>
+        <span>Acme</span>
+      </BrandChallengePromptsTooltip>,
+    );
+
+    const trigger = getByText('Acme').parentElement!;
+    expect(trigger.getAttribute('tabindex')).toBe('0');
+  });
+
+  test('renders children unwrapped when prompts is undefined or empty', () => {
+    const { getByText, queryByRole, rerender } = render(
+      <BrandChallengePromptsTooltip prompts={undefined}>
+        <span>Acme</span>
+      </BrandChallengePromptsTooltip>,
+    );
+    fireEvent.mouseOver(getByText('Acme'));
+    expect(queryByRole('tooltip')).toBeNull();
+
+    rerender(
+      <BrandChallengePromptsTooltip prompts={[]}>
+        <span>Acme</span>
+      </BrandChallengePromptsTooltip>,
+    );
+    fireEvent.mouseOver(getByText('Acme'));
+    expect(queryByRole('tooltip')).toBeNull();
+  });
+});
+
+describe('<LazyBrandChallengePromptsTooltip/>', () => {
+  test('does not mount Tooltip until hovered, then shows it on subsequent hover', async () => {
+    const { getByText, queryByRole, findByRole } = render(
+      <LazyBrandChallengePromptsTooltip prompts={PROMPTS}>
+        Acme
+      </LazyBrandChallengePromptsTooltip>,
+    );
+
+    // Pre-activation: no tooltip role anywhere.
+    expect(queryByRole('tooltip')).toBeNull();
+
+    // First mouseOver activates the lazy wrapper; the Tooltip mounts on
+    // subsequent interaction.
+    fireEvent.mouseOver(getByText('Acme'));
+    fireEvent.mouseOver(getByText('Acme'));
+
+    const tooltip = await findByRole('tooltip');
+    expect(tooltip.textContent).toContain('Birth Date: Always');
+  });
+
+  test('stays inert when prompts empty', () => {
+    const { getByText, queryByRole } = render(
+      <LazyBrandChallengePromptsTooltip prompts={[]}>
+        Acme
+      </LazyBrandChallengePromptsTooltip>,
+    );
+
+    fireEvent.mouseOver(getByText('Acme'));
+    fireEvent.mouseOver(getByText('Acme'));
+
+    expect(queryByRole('tooltip')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Adds a tooltip that shows current challenge prompts configuration for a given brand and applies the tooltip to metrics charts legend and billable events table.

## Changes
- feat: add BrandChallengePromptsTooltip and format utilities for challenge prompts
- feat: integrate LazyBrandChallengePromptsTooltip and add challenge prompts support in BillableEventsTable
- feat: add challenge prompts support to SeriesChart and SeriesPercentageChartLegend components
- feat: add challenge prompts to Brands interface and SynchronizedMetricsChart component
- feat: add challenge prompts support to BillableEventsTable and ConversionOverTimeChart components

## Testing
All unit tests pass, new tests were added.
New storybook stories include the tooltip usage.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [x] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
