### PR TITLE
feat/add-brand-details-to-billing-table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "9.13.1-beta.0",
+  "version": "9.13.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@verifiedinc-public/shared-ui-elements",
-      "version": "9.13.1-beta.0",
+      "version": "9.13.1-beta.1",
       "dependencies": {
         "date-fns-tz": "^3.2.0",
         "react-datepicker": "^7.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "9.13.0",
+  "version": "9.13.1-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@verifiedinc-public/shared-ui-elements",
-      "version": "9.13.0",
+      "version": "9.13.1-beta.0",
       "dependencies": {
         "date-fns-tz": "^3.2.0",
         "react-datepicker": "^7.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "9.13.1-beta.0",
+  "version": "9.13.1-beta.1",
   "description": "A set of UI components, utilities that is shareable with the core apps.",
   "private": false,
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "9.13.0",
+  "version": "9.13.1-beta.0",
   "description": "A set of UI components, utilities that is shareable with the core apps.",
   "private": false,
   "sideEffects": false,

--- a/src/components/chart/BillableEventsTable/BillableEventsTable.tsx
+++ b/src/components/chart/BillableEventsTable/BillableEventsTable.tsx
@@ -8,7 +8,7 @@ import {
   TableRow,
   TableSortLabel,
 } from '@mui/material';
-import React, { useEffect, useMemo } from 'react';
+import React, { Fragment, useEffect, useMemo, useState } from 'react';
 
 import { EmptyChartSection } from '../EmptyChartSection';
 import { LoadingChartSection } from '../LoadingChartSection';
@@ -19,11 +19,11 @@ import {
   type BillableEventsTableProps,
   type BillableEventsTableRow,
 } from './BillableEventsTable.types';
+import { BrandDetailsPanel } from './BrandDetailsPanel';
 import { useBillableSort } from './useBillableSort.hook';
-import { CopyableUuid } from '../../CopyableUuid';
 import { white } from '../../../styles';
 
-const DIRECT_KEYS = ['brand', 'integrationType'];
+const DIRECT_KEYS = ['customerName', 'brand', 'integrationType'];
 
 export const BillableEventsTable: React.FC<BillableEventsTableProps> = ({
   data,
@@ -36,6 +36,10 @@ export const BillableEventsTable: React.FC<BillableEventsTableProps> = ({
 }) => {
   const { sortKey, sortDir, handleSort, sortedData } =
     useBillableSort<BillableEventsTableRow>(data, DIRECT_KEYS, 'brand');
+
+  const [expandedBrandUuid, setExpandedBrandUuid] = useState<string | null>(
+    null,
+  );
 
   useEffect(() => {
     onSortedDataChange?.(sortedData);
@@ -56,6 +60,11 @@ export const BillableEventsTable: React.FC<BillableEventsTableProps> = ({
       .flatMap((p) => p.columns)
       .filter((c) => !topLevelColumnKeys.has(c.key));
   }, [activeProducts, topLevelColumnKeys]);
+
+  // Customer Name + Brand Name + Integration Type = 3 fixed cells.
+  const fixedColumnCount = 3;
+  const totalColumnCount =
+    fixedColumnCount + topLevelColumns.length + allColumns.length;
 
   const sortLabel = (
     key: string,
@@ -87,9 +96,11 @@ export const BillableEventsTable: React.FC<BillableEventsTableProps> = ({
           {/* Product group header row */}
           <TableRow>
             <TableCell rowSpan={2}>
+              {sortLabel('customerName', 'Customer Name')}
+            </TableCell>
+            <TableCell rowSpan={2}>
               {sortLabel('brand', 'Brand Name')}
             </TableCell>
-            <TableCell rowSpan={2}>Brand UUID</TableCell>
             <TableCell rowSpan={2}>
               {sortLabel('integrationType', 'Integration Type')}
             </TableCell>
@@ -125,38 +136,63 @@ export const BillableEventsTable: React.FC<BillableEventsTableProps> = ({
           </TableRow>
         </TableHead>
         <TableBody>
-          {sortedData.map((row: BillableEventsTableRow) => (
-            <TableRow key={row.brandUuid}>
-              <TableCell>{row.brand}</TableCell>
-              <TableCell>
-                <CopyableUuid
-                  uuid={row.brandUuid}
-                  label='Brand UUID'
-                  variant='button'
-                  head={6}
-                  tail={0}
-                  mono={false}
-                  iconSx={{ color: 'success.main' }}
-                  typographyProps={{ variant: 'inherit', color: 'inherit' }}
-                />
-              </TableCell>
-              <TableCell>{row.integrationType}</TableCell>
-              {topLevelColumns.map((col: BillableEventColumn) => (
-                <TableCell key={col.key}>
-                  {columnSlots?.[col.key]
-                    ? columnSlots[col.key](row)
-                    : (row.metrics[col.key] ?? 0)}
-                </TableCell>
-              ))}
-              {allColumns.map((col: BillableEventColumn) => (
-                <TableCell key={col.key} align='right'>
-                  {columnSlots?.[col.key]
-                    ? columnSlots[col.key](row)
-                    : (row.metrics[col.key] ?? 0)}
-                </TableCell>
-              ))}
-            </TableRow>
-          ))}
+          {sortedData.map((row: BillableEventsTableRow) => {
+            const isExpanded = expandedBrandUuid === row.brandUuid;
+            return (
+              <Fragment key={row.brandUuid}>
+                <TableRow
+                  hover
+                  onClick={() =>
+                    setExpandedBrandUuid(isExpanded ? null : row.brandUuid)
+                  }
+                  sx={{
+                    cursor: 'pointer',
+                    '& > td': {
+                      borderBottom: isExpanded ? 'none' : undefined,
+                    },
+                  }}
+                >
+                  <TableCell>{row.customerName ?? '—'}</TableCell>
+                  <TableCell>{row.brand}</TableCell>
+                  <TableCell>{row.integrationType}</TableCell>
+                  {topLevelColumns.map((col: BillableEventColumn) => (
+                    <TableCell key={col.key}>
+                      {columnSlots?.[col.key]
+                        ? columnSlots[col.key](row)
+                        : (row.metrics[col.key] ?? 0)}
+                    </TableCell>
+                  ))}
+                  {allColumns.map((col: BillableEventColumn) => (
+                    <TableCell key={col.key} align='right'>
+                      {columnSlots?.[col.key]
+                        ? columnSlots[col.key](row)
+                        : (row.metrics[col.key] ?? 0)}
+                    </TableCell>
+                  ))}
+                </TableRow>
+                {isExpanded && (
+                  <TableRow>
+                    <TableCell
+                      colSpan={totalColumnCount}
+                      sx={{
+                        py: 0,
+                        px: 0,
+                        borderTop: 'none',
+                        bgcolor: 'grey.50',
+                      }}
+                    >
+                      <BrandDetailsPanel
+                        brandUuid={row.brandUuid}
+                        customerUuid={row.customerUuid}
+                        challengePrompts={row.challengePrompts}
+                        providers={row.providers}
+                      />
+                    </TableCell>
+                  </TableRow>
+                )}
+              </Fragment>
+            );
+          })}
         </TableBody>
       </Table>
     </TableContainer>

--- a/src/components/chart/BillableEventsTable/BillableEventsTable.tsx
+++ b/src/components/chart/BillableEventsTable/BillableEventsTable.tsx
@@ -33,6 +33,7 @@ export const BillableEventsTable: React.FC<BillableEventsTableProps> = ({
   onSortedDataChange,
   columnSlots,
   topLevelColumns = [],
+  showCustomerColumn = true,
 }) => {
   const { sortKey, sortDir, handleSort, sortedData } =
     useBillableSort<BillableEventsTableRow>(data, DIRECT_KEYS, 'brand');
@@ -61,8 +62,8 @@ export const BillableEventsTable: React.FC<BillableEventsTableProps> = ({
       .filter((c) => !topLevelColumnKeys.has(c.key));
   }, [activeProducts, topLevelColumnKeys]);
 
-  // Customer Name + Brand Name + Integration Type = 3 fixed cells.
-  const fixedColumnCount = 3;
+  // Brand Name + Integration Type = 2 fixed cells, plus Customer Name when shown.
+  const fixedColumnCount = 2 + (showCustomerColumn ? 1 : 0);
   const totalColumnCount =
     fixedColumnCount + topLevelColumns.length + allColumns.length;
 
@@ -95,9 +96,11 @@ export const BillableEventsTable: React.FC<BillableEventsTableProps> = ({
         <TableHead>
           {/* Product group header row */}
           <TableRow>
-            <TableCell rowSpan={2}>
-              {sortLabel('customerName', 'Customer Name')}
-            </TableCell>
+            {showCustomerColumn && (
+              <TableCell rowSpan={2}>
+                {sortLabel('customerName', 'Customer Name')}
+              </TableCell>
+            )}
             <TableCell rowSpan={2}>
               {sortLabel('brand', 'Brand Name')}
             </TableCell>
@@ -152,7 +155,9 @@ export const BillableEventsTable: React.FC<BillableEventsTableProps> = ({
                     },
                   }}
                 >
-                  <TableCell>{row.customerName ?? '—'}</TableCell>
+                  {showCustomerColumn && (
+                    <TableCell>{row.customerName ?? '—'}</TableCell>
+                  )}
                   <TableCell>{row.brand}</TableCell>
                   <TableCell>{row.integrationType}</TableCell>
                   {topLevelColumns.map((col: BillableEventColumn) => (
@@ -183,7 +188,9 @@ export const BillableEventsTable: React.FC<BillableEventsTableProps> = ({
                     >
                       <BrandDetailsPanel
                         brandUuid={row.brandUuid}
-                        customerUuid={row.customerUuid}
+                        customerUuid={
+                          showCustomerColumn ? row.customerUuid : undefined
+                        }
                         challengePrompts={row.challengePrompts}
                         providers={row.providers}
                       />

--- a/src/components/chart/BillableEventsTable/BillableEventsTable.types.ts
+++ b/src/components/chart/BillableEventsTable/BillableEventsTable.types.ts
@@ -1,6 +1,17 @@
 import React from 'react';
 import { ChartData } from '../BillableEventsProductTable';
 
+export type ChallengePrompt = {
+  type: string;
+  promptForChallenge: string;
+};
+
+export type BrandProviders = {
+  allowedProviders?: string[];
+  healthDataProviders?: string[];
+  healthDataProviderMode?: string;
+};
+
 export enum BillableProduct {
   TEXT_TO_SIGNUP = 'TEXT_TO_SIGNUP',
   ONE_CLICK_VERIFY = 'ONE_CLICK_VERIFY',
@@ -85,9 +96,13 @@ export const BILLABLE_PRODUCTS: BillableProductConfig[] = [
 export type BillableEventsTableRow = {
   brandUuid: string;
   brand: string;
+  customerUuid?: string;
+  customerName?: string;
   integrationType: string;
   metrics: Record<string, number>;
   raw: ChartData;
+  challengePrompts?: ChallengePrompt[];
+  providers?: BrandProviders;
 };
 
 export type BillableEventsTableProps = {

--- a/src/components/chart/BillableEventsTable/BillableEventsTable.types.ts
+++ b/src/components/chart/BillableEventsTable/BillableEventsTable.types.ts
@@ -116,6 +116,11 @@ export type BillableEventsTableProps = {
     (row: BillableEventsTableRow) => React.ReactNode
   >;
   topLevelColumns?: BillableEventColumn[];
+  /**
+   * Show the leading Customer Name column. Defaults to `true`. Set `false`
+   * for views scoped to a single customer where the column would be redundant.
+   */
+  showCustomerColumn?: boolean;
 };
 
 export type BillableEventsProductTableProps = {

--- a/src/components/chart/BillableEventsTable/BrandDetailsPanel.tsx
+++ b/src/components/chart/BillableEventsTable/BrandDetailsPanel.tsx
@@ -1,7 +1,10 @@
 import { Box, Stack, Typography } from '@mui/material';
 
 import { CopyableUuid } from '../../CopyableUuid';
-import type { BrandProviders, ChallengePrompt } from './BillableEventsTable.types';
+import type {
+  BrandProviders,
+  ChallengePrompt,
+} from './BillableEventsTable.types';
 import {
   formatChallengeInput,
   formatHealthDataProviderMode,
@@ -73,10 +76,7 @@ export function BrandDetailsPanel({
   return (
     <Box sx={{ p: 2 }}>
       <Stack spacing={3}>
-        <IdentifiersSection
-          brandUuid={brandUuid}
-          customerUuid={customerUuid}
-        />
+        <IdentifiersSection brandUuid={brandUuid} customerUuid={customerUuid} />
         <SettingsSection
           challengePrompts={challengePrompts}
           providers={providers}
@@ -243,7 +243,11 @@ function DataProvidersSubsection({
   providers,
   mode,
   ordered,
-}: Readonly<{ providers: string[]; mode?: string, ordered: boolean }>): JSX.Element {
+}: Readonly<{
+  providers: string[];
+  mode?: string;
+  ordered: boolean;
+}>): JSX.Element {
   if (providers.length === 0) {
     return (
       <Box>

--- a/src/components/chart/BillableEventsTable/BrandDetailsPanel.tsx
+++ b/src/components/chart/BillableEventsTable/BrandDetailsPanel.tsx
@@ -1,0 +1,294 @@
+import { Box, Stack, Typography } from '@mui/material';
+
+import { CopyableUuid } from '../../CopyableUuid';
+import type { BrandProviders, ChallengePrompt } from './BillableEventsTable.types';
+import {
+  formatChallengeInput,
+  formatHealthDataProviderMode,
+  formatPromptForChallenge,
+} from './format';
+
+interface BrandDetailsPanelProps {
+  brandUuid: string;
+  customerUuid?: string;
+  challengePrompts?: ChallengePrompt[];
+  providers?: BrandProviders;
+}
+
+const SECTION_HEADER_SX = {
+  fontSize: 11,
+  fontWeight: 700,
+  letterSpacing: 0.6,
+  textTransform: 'uppercase' as const,
+  color: 'text.primary',
+  mb: 1.5,
+};
+
+const PRODUCT_HEADER_SX = {
+  fontSize: 14,
+  fontWeight: 700,
+  color: 'text.primary',
+  mb: 1,
+};
+
+const SUBSECTION_HEADER_SX = {
+  fontSize: 12,
+  fontWeight: 600,
+  color: 'text.secondary',
+  mb: 0.5,
+};
+
+const LIST_SX = {
+  m: 0,
+  pl: 3,
+  '& li': { mb: 0.25 },
+  '& li::marker': {
+    color: 'text.secondary',
+    fontWeight: 500,
+  },
+};
+
+const IDENTIFIER_LABEL_SX = {
+  fontSize: 12,
+  color: 'text.secondary',
+  mr: 0.75,
+};
+
+export function BrandDetailsPanel({
+  brandUuid,
+  customerUuid,
+  challengePrompts,
+  providers,
+}: Readonly<BrandDetailsPanelProps>): JSX.Element {
+  const hasSignupProviders = Boolean(
+    providers?.allowedProviders && providers.allowedProviders.length > 0,
+  );
+  const hasHealth = Boolean(
+    providers &&
+      ((providers.healthDataProviders &&
+        providers.healthDataProviders.length > 0) ||
+        providers.healthDataProviderMode),
+  );
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Stack spacing={3}>
+        <IdentifiersSection
+          brandUuid={brandUuid}
+          customerUuid={customerUuid}
+        />
+        <SettingsSection
+          challengePrompts={challengePrompts}
+          providers={providers}
+          hasSignupProviders={hasSignupProviders}
+          hasHealth={hasHealth}
+        />
+      </Stack>
+    </Box>
+  );
+}
+
+function IdentifiersSection({
+  brandUuid,
+  customerUuid,
+}: Readonly<{ brandUuid: string; customerUuid?: string }>): JSX.Element {
+  return (
+    <Box>
+      <Typography sx={SECTION_HEADER_SX}>Identifiers</Typography>
+      <Stack
+        direction={{ xs: 'column', sm: 'column' }}
+        spacing={{ xs: 0.5, sm: 0.5 }}
+      >
+        <IdentifierField label='Brand UUID' value={brandUuid} />
+        {customerUuid && (
+          <IdentifierField label='Customer UUID' value={customerUuid} />
+        )}
+      </Stack>
+    </Box>
+  );
+}
+
+function IdentifierField({
+  label,
+  value,
+}: Readonly<{ label: string; value: string }>): JSX.Element {
+  return (
+    <Stack direction='row' alignItems='center'>
+      <Typography component='span' sx={IDENTIFIER_LABEL_SX}>
+        {label}:
+      </Typography>
+      <CopyableUuid
+        uuid={value}
+        label={label}
+        variant='button'
+        head={36}
+        mono
+        typographyProps={{ fontWeight: 800 }}
+        iconSx={{ fontSize: 14, p: 0.125 }}
+      />
+    </Stack>
+  );
+}
+
+function SettingsSection({
+  challengePrompts,
+  providers,
+  hasSignupProviders,
+  hasHealth,
+}: Readonly<{
+  challengePrompts?: ChallengePrompt[];
+  providers?: BrandProviders;
+  hasSignupProviders: boolean;
+  hasHealth: boolean;
+}>): JSX.Element {
+  return (
+    <Box>
+      <Typography sx={SECTION_HEADER_SX}>Settings</Typography>
+      <Stack
+        direction={{ xs: 'column', md: 'row' }}
+        spacing={4}
+        alignItems='flex-start'
+      >
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <OneClickSignupColumn
+            challengePrompts={challengePrompts}
+            allowedProviders={providers?.allowedProviders}
+            hasSignupProviders={hasSignupProviders}
+          />
+        </Box>
+        {hasHealth && providers && (
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <OneClickHealthColumn providers={providers} />
+          </Box>
+        )}
+      </Stack>
+    </Box>
+  );
+}
+
+function OneClickSignupColumn({
+  challengePrompts,
+  allowedProviders,
+  hasSignupProviders,
+}: Readonly<{
+  challengePrompts?: ChallengePrompt[];
+  allowedProviders?: string[];
+  hasSignupProviders: boolean;
+}>): JSX.Element {
+  return (
+    <Box>
+      <Typography sx={PRODUCT_HEADER_SX}>1-Click Signup</Typography>
+      <Stack spacing={1.5}>
+        <ChallengesSubsection prompts={challengePrompts} />
+        {hasSignupProviders && allowedProviders && (
+          <DataProvidersSubsection providers={allowedProviders} ordered />
+        )}
+      </Stack>
+    </Box>
+  );
+}
+
+function OneClickHealthColumn({
+  providers,
+}: Readonly<{ providers: BrandProviders }>): JSX.Element {
+  const healthProviders = providers.healthDataProviders ?? [];
+  const isParallel = providers.healthDataProviderMode === 'parallel';
+
+  return (
+    <Box>
+      <Typography sx={PRODUCT_HEADER_SX}>1-Click Health</Typography>
+      <DataProvidersSubsection
+        providers={healthProviders}
+        mode={providers.healthDataProviderMode}
+        ordered={!isParallel}
+      />
+    </Box>
+  );
+}
+
+function ChallengesSubsection({
+  prompts,
+}: Readonly<{ prompts?: ChallengePrompt[] }>): JSX.Element {
+  return (
+    <Box>
+      <Typography sx={SUBSECTION_HEADER_SX}>Challenges</Typography>
+      {prompts && prompts.length > 0 ? (
+        <Box component='ol' sx={LIST_SX}>
+          {prompts.map((prompt, index) => (
+            <Typography
+              key={`${prompt.type}-${index}`}
+              component='li'
+              variant='body2'
+            >
+              {formatChallengeInput(prompt.type)} (
+              {formatPromptForChallenge(prompt.promptForChallenge)})
+            </Typography>
+          ))}
+        </Box>
+      ) : (
+        <Typography
+          variant='body2'
+          color='text.secondary'
+          fontStyle='italic'
+          sx={{ pl: 1 }}
+        >
+          None configured
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
+function DataProvidersSubsection({
+  providers,
+  mode,
+  ordered,
+}: Readonly<{ providers: string[]; mode?: string, ordered: boolean }>): JSX.Element {
+  if (providers.length === 0) {
+    return (
+      <Box>
+        <Typography sx={SUBSECTION_HEADER_SX}>Data Providers</Typography>
+        <Typography
+          variant='body2'
+          color='text.secondary'
+          fontStyle='italic'
+          sx={{ pl: 1 }}
+        >
+          None configured
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Typography sx={SUBSECTION_HEADER_SX}>Data Providers</Typography>
+      {mode && (
+        <Stack
+          direction='row'
+          alignItems='baseline'
+          spacing={0.5}
+          sx={{ mb: 0.5 }}
+        >
+          <Typography component='span' sx={IDENTIFIER_LABEL_SX}>
+            Mode:
+          </Typography>
+          <Typography component='span' variant='body2' fontWeight={600}>
+            {formatHealthDataProviderMode(mode)}
+          </Typography>
+        </Stack>
+      )}
+      <Box component={ordered ? 'ol' : 'ul'} sx={LIST_SX}>
+        {providers.map((provider, index) => (
+          <Typography
+            key={`${provider}-${index}`}
+            component='li'
+            variant='body2'
+          >
+            {provider}
+          </Typography>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/chart/BillableEventsTable/exportBillableEventsToCsv.ts
+++ b/src/components/chart/BillableEventsTable/exportBillableEventsToCsv.ts
@@ -43,8 +43,10 @@ export function exportBillableEventsToCsv({
   const rows: string[] = [];
 
   // Row 1: Product group header.
-  // Leading empty cells align with Brand, UUID, Integration Type, and each topLevelColumn.
-  const groupHeader = ['', '', '', ...topLevelColumns.map(() => '')];
+  // Leading empty cells align with the 5 fixed columns (Customer Name,
+  // Customer UUID, Brand Name, Brand UUID, Integration Type) and each
+  // topLevelColumn.
+  const groupHeader = ['', '', '', '', '', ...topLevelColumns.map(() => '')];
   for (const product of activeProducts) {
     const visibleCount = product.columns.filter(
       (c) => !topLevelKeys.has(c.key),
@@ -58,7 +60,13 @@ export function exportBillableEventsToCsv({
   rows.push(groupHeader.join(','));
 
   // Row 2: Column header
-  const columnHeader = ['Brand Name', 'Brand UUID', 'Integration Type'];
+  const columnHeader = [
+    'Customer Name',
+    'Customer UUID',
+    'Brand Name',
+    'Brand UUID',
+    'Integration Type',
+  ];
   for (const col of topLevelColumns) {
     columnHeader.push(escapeCsvValue(col.label));
   }
@@ -70,6 +78,8 @@ export function exportBillableEventsToCsv({
   // Data rows
   for (const row of data) {
     const csvRow = [
+      escapeCsvValue(row.customerName ?? ''),
+      escapeCsvValue(row.customerUuid ?? ''),
       escapeCsvValue(row.brand),
       escapeCsvValue(row.brandUuid),
       escapeCsvValue(row.integrationType),

--- a/src/components/chart/BillableEventsTable/exportBillableEventsToCsv.ts
+++ b/src/components/chart/BillableEventsTable/exportBillableEventsToCsv.ts
@@ -22,6 +22,11 @@ interface ExportBillableEventsToCsvOptions {
     string,
     (value: number, row: BillableEventsTableRow) => string
   >;
+  /**
+   * Include the `Customer Name` and `Customer UUID` columns. Defaults to
+   * `true`. Set `false` for single-customer-scoped exports.
+   */
+  showCustomerColumn?: boolean;
 }
 
 export function exportBillableEventsToCsv({
@@ -30,6 +35,7 @@ export function exportBillableEventsToCsv({
   filename = 'billable-events',
   topLevelColumns = [],
   columnFormatters,
+  showCustomerColumn = true,
 }: ExportBillableEventsToCsvOptions): void {
   const products = visibleProducts ?? Object.values(BillableProduct);
   const activeProducts = BILLABLE_PRODUCTS.filter((p) =>
@@ -43,10 +49,14 @@ export function exportBillableEventsToCsv({
   const rows: string[] = [];
 
   // Row 1: Product group header.
-  // Leading empty cells align with the 5 fixed columns (Customer Name,
-  // Customer UUID, Brand Name, Brand UUID, Integration Type) and each
-  // topLevelColumn.
-  const groupHeader = ['', '', '', '', '', ...topLevelColumns.map(() => '')];
+  // Leading empty cells align with the fixed columns (Customer Name,
+  // Customer UUID, both optional, Brand Name, Brand UUID, Integration
+  // Type) and each topLevelColumn.
+  const fixedColumnCount = (showCustomerColumn ? 2 : 0) + 3;
+  const groupHeader = [
+    ...new Array(fixedColumnCount).fill(''),
+    ...topLevelColumns.map(() => ''),
+  ];
   for (const product of activeProducts) {
     const visibleCount = product.columns.filter(
       (c) => !topLevelKeys.has(c.key),
@@ -61,8 +71,7 @@ export function exportBillableEventsToCsv({
 
   // Row 2: Column header
   const columnHeader = [
-    'Customer Name',
-    'Customer UUID',
+    ...(showCustomerColumn ? ['Customer Name', 'Customer UUID'] : []),
     'Brand Name',
     'Brand UUID',
     'Integration Type',
@@ -78,8 +87,12 @@ export function exportBillableEventsToCsv({
   // Data rows
   for (const row of data) {
     const csvRow = [
-      escapeCsvValue(row.customerName ?? ''),
-      escapeCsvValue(row.customerUuid ?? ''),
+      ...(showCustomerColumn
+        ? [
+            escapeCsvValue(row.customerName ?? ''),
+            escapeCsvValue(row.customerUuid ?? ''),
+          ]
+        : []),
       escapeCsvValue(row.brand),
       escapeCsvValue(row.brandUuid),
       escapeCsvValue(row.integrationType),

--- a/src/components/chart/BillableEventsTable/format.ts
+++ b/src/components/chart/BillableEventsTable/format.ts
@@ -1,0 +1,34 @@
+/**
+ * Display formatters for brand-settings panel content.
+ *
+ * Each map uses lookup-and-fallback so a new enum member shows its raw
+ * value rather than breaking compilation.
+ */
+
+const CHALLENGE_INPUT_LABELS: Record<string, string> = {
+  birthDate: 'Birth Date',
+  ssn4: 'SSN4',
+  'fullName.firstName': 'First Name',
+};
+
+const PROMPT_FOR_CHALLENGE_LABELS: Record<string, string> = {
+  always: 'always',
+  ifNecessary: 'if necessary',
+};
+
+const HEALTH_DATA_PROVIDER_MODE_LABELS: Record<string, string> = {
+  fallback: 'Fallback',
+  parallel: 'Parallel',
+};
+
+export function formatChallengeInput(type: string): string {
+  return CHALLENGE_INPUT_LABELS[type] ?? type;
+}
+
+export function formatPromptForChallenge(prompt: string): string {
+  return PROMPT_FOR_CHALLENGE_LABELS[prompt] ?? prompt;
+}
+
+export function formatHealthDataProviderMode(mode: string): string {
+  return HEALTH_DATA_PROVIDER_MODE_LABELS[mode] ?? mode;
+}

--- a/src/components/chart/BillableEventsTable/index.ts
+++ b/src/components/chart/BillableEventsTable/index.ts
@@ -1,4 +1,6 @@
 export * from './BillableEventsTable.types';
 export * from './BillableEventsTable';
 export * from './BillableEventsTableDataMapper';
+export * from './BrandDetailsPanel';
 export * from './exportBillableEventsToCsv';
+export * from './format';

--- a/src/stories/components/chart/BillableEventsTable.stories.tsx
+++ b/src/stories/components/chart/BillableEventsTable.stories.tsx
@@ -20,10 +20,15 @@ const meta: Meta<typeof BillableEventsTable> = {
 export default meta;
 type Story = StoryObj<typeof BillableEventsTable>;
 
+const HOOLI_CUSTOMER_UUID = 'a0000000-0000-0000-0000-000000000001';
+const PIED_PIPER_CUSTOMER_UUID = 'a0000000-0000-0000-0000-000000000002';
+
 const mockData: BillableEventsTableRow[] = [
   {
     brandUuid: 'c44d24d0-8cef-4fcc-ad37-1fe154d97e57',
     brand: 'Hooli Health',
+    customerUuid: HOOLI_CUSTOMER_UUID,
+    customerName: 'Hooli',
     integrationType: 'SDK',
     raw: {
       brandUuid: 'c44d24d0-8cef-4fcc-ad37-1fe154d97e57',
@@ -39,10 +44,22 @@ const mockData: BillableEventsTableRow[] = [
       signup_riskSignals: 5,
       health_autofillsStarted: 5,
     },
+    challengePrompts: [
+      { type: 'birthDate', promptForChallenge: 'always' },
+      { type: 'fullName.firstName', promptForChallenge: 'ifNecessary' },
+      { type: 'ssn4', promptForChallenge: 'ifNecessary' },
+    ],
+    providers: {
+      allowedProviders: ['Acme', 'Aviato'],
+      healthDataProviders: ['Pied Piper', 'Acme Health'],
+      healthDataProviderMode: 'fallback',
+    },
   },
   {
     brandUuid: '',
     brand: 'Pied Piper',
+    customerUuid: PIED_PIPER_CUSTOMER_UUID,
+    customerName: 'Pied Piper',
     integrationType: 'API',
     raw: { brandUuid: '', brandName: 'Pied Piper', overall: {} },
     metrics: {
@@ -54,10 +71,19 @@ const mockData: BillableEventsTableRow[] = [
       signup_riskSignals: 2,
       health_autofillsStarted: 20,
     },
+    challengePrompts: [
+      { type: 'birthDate', promptForChallenge: 'always' },
+      { type: 'fullName.firstName', promptForChallenge: 'ifNecessary' },
+    ],
+    providers: {
+      allowedProviders: ['Acme'],
+    },
   },
   {
     brandUuid: '42f12a06-47a7-46bf-901b-e4a8227266d0',
     brand: 'Aviato',
+    customerUuid: HOOLI_CUSTOMER_UUID,
+    customerName: 'Hooli',
     integrationType: 'Semi-Hosted',
     raw: {
       brandUuid: '42f12a06-47a7-46bf-901b-e4a8227266d0',
@@ -75,6 +101,26 @@ const mockData: BillableEventsTableRow[] = [
     },
   },
 ];
+
+const mockDataWithoutProviders: BillableEventsTableRow[] = mockData.map(
+  (row) => {
+    const { providers: _providers, ...rest } = row;
+    return rest;
+  },
+);
+
+const mockDataWithParallelHealth: BillableEventsTableRow[] = mockData.map(
+  (row) => {
+    if (!row.providers?.healthDataProviders) return row;
+    return {
+      ...row,
+      providers: {
+        ...row.providers,
+        healthDataProviderMode: 'parallel',
+      },
+    };
+  },
+);
 
 export const AllProducts: Story = {
   args: {
@@ -128,6 +174,22 @@ export const WithColumnSlots: Story = {
         />
       ),
     },
+  },
+};
+
+export const WithoutProviders: Story = {
+  args: {
+    data: mockDataWithoutProviders,
+    isLoading: false,
+    isFetching: false,
+  },
+};
+
+export const WithParallelHealth: Story = {
+  args: {
+    data: mockDataWithParallelHealth,
+    isLoading: false,
+    isFetching: false,
   },
 };
 

--- a/tests/components/chart/BillableEventsTable.test.tsx
+++ b/tests/components/chart/BillableEventsTable.test.tsx
@@ -315,6 +315,12 @@ describe('<BillableEventsTable/>', () => {
 
 describe('exportBillableEventsToCsv', () => {
   let capturedBlob: Blob | null;
+  // `vi.restoreAllMocks()` only restores `vi.spyOn` targets — it does NOT
+  // undo `Object.defineProperty` overrides. Capture the originals here and
+  // restore them in afterEach so URL.createObjectURL / revokeObjectURL don't
+  // leak the mock into later test files.
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
 
   beforeEach(() => {
     capturedBlob = null;
@@ -343,6 +349,14 @@ describe('exportBillableEventsToCsv', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: originalCreateObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: originalRevokeObjectURL,
+    });
   });
 
   test('header includes Customer Name + Customer UUID + Brand Name + Brand UUID + Integration Type', async () => {

--- a/tests/components/chart/BillableEventsTable.test.tsx
+++ b/tests/components/chart/BillableEventsTable.test.tsx
@@ -1,0 +1,306 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, fireEvent, render, within } from '@testing-library/react';
+
+import {
+  BillableEventsTable,
+  BillableProduct,
+  exportBillableEventsToCsv,
+  type BillableEventsTableRow,
+} from '../../../src/components/chart/BillableEventsTable';
+
+const HOOLI_CUSTOMER = 'a0000000-0000-0000-0000-000000000001';
+const PIED_PIPER_CUSTOMER = 'a0000000-0000-0000-0000-000000000002';
+
+function makeRow(
+  overrides: Partial<BillableEventsTableRow>,
+): BillableEventsTableRow {
+  return {
+    brandUuid: overrides.brandUuid ?? 'brand-1',
+    brand: overrides.brand ?? 'Brand 1',
+    customerUuid: overrides.customerUuid ?? HOOLI_CUSTOMER,
+    customerName: overrides.customerName ?? 'Hooli',
+    integrationType: overrides.integrationType ?? 'SDK',
+    metrics: overrides.metrics ?? { signup_autofillsSucceeded: 1 },
+    raw: overrides.raw ?? {
+      brandUuid: overrides.brandUuid ?? 'brand-1',
+      brandName: overrides.brand ?? 'Brand 1',
+      overall: {},
+    },
+    challengePrompts: overrides.challengePrompts,
+    providers: overrides.providers,
+  };
+}
+
+const baseData: BillableEventsTableRow[] = [
+  makeRow({
+    brandUuid: 'aviato-uuid',
+    brand: 'Aviato',
+    customerUuid: HOOLI_CUSTOMER,
+    customerName: 'Hooli',
+    challengePrompts: [
+      { type: 'birthDate', promptForChallenge: 'always' },
+      { type: 'fullName.firstName', promptForChallenge: 'ifNecessary' },
+    ],
+    providers: {
+      allowedProviders: ['Acme', 'Pied Piper'],
+      healthDataProviders: ['Aviato', 'Acme Health'],
+      healthDataProviderMode: 'fallback',
+    },
+  }),
+  makeRow({
+    brandUuid: 'pied-piper-uuid',
+    brand: 'Pied Piper',
+    customerUuid: PIED_PIPER_CUSTOMER,
+    customerName: 'Pied Piper',
+  }),
+];
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('<BillableEventsTable/>', () => {
+  test('Brand UUID column is no longer in the header', () => {
+    const { queryByText } = render(
+      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+    );
+    // Header used to read 'Brand UUID' — now lives in the expanded panel only.
+    expect(queryByText('Brand UUID:')).toBeNull();
+  });
+
+  test('renders Customer Name column with values', () => {
+    const { getByText } = render(
+      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+    );
+    expect(getByText('Customer Name')).toBeDefined();
+    expect(getByText('Hooli')).toBeDefined();
+    expect(getByText('Pied Piper')).toBeDefined();
+  });
+
+  test('renders em-dash placeholder when customerName is missing', () => {
+    const data = [
+      makeRow({
+        brandUuid: 'orphan-uuid',
+        brand: 'Orphan',
+        customerUuid: undefined,
+        customerName: undefined,
+      }),
+    ];
+    const { getAllByText } = render(
+      <BillableEventsTable data={data} isLoading={false} isFetching={false} />,
+    );
+    expect(getAllByText('—').length).toBeGreaterThan(0);
+  });
+
+  test('sort by Customer Name (asc then desc)', () => {
+    const { getByText, container } = render(
+      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+    );
+
+    fireEvent.click(getByText('Customer Name'));
+    let firstRowText =
+      container.querySelectorAll('tbody tr')[0]?.textContent ?? '';
+    expect(firstRowText).toContain('Hooli');
+
+    fireEvent.click(getByText('Customer Name'));
+    firstRowText =
+      container.querySelectorAll('tbody tr')[0]?.textContent ?? '';
+    expect(firstRowText).toContain('Pied Piper');
+  });
+
+  test('whole-row click toggles the panel', () => {
+    const { container, queryByText, getByText } = render(
+      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+    );
+
+    expect(queryByText('Identifiers')).toBeNull();
+
+    const aviatoRow = within(container).getByText('Aviato').closest('tr');
+    expect(aviatoRow).not.toBeNull();
+    fireEvent.click(aviatoRow!);
+
+    expect(getByText('Identifiers')).toBeDefined();
+    expect(getByText('Settings')).toBeDefined();
+
+    fireEvent.click(aviatoRow!);
+    expect(queryByText('Identifiers')).toBeNull();
+  });
+
+  test('only one row is expanded at a time', () => {
+    const { container, getAllByText } = render(
+      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+    );
+
+    const aviatoRow = within(container).getByText('Aviato').closest('tr');
+    const pipRow = within(container).getByText('Pied Piper').closest('tr');
+
+    fireEvent.click(aviatoRow!);
+    expect(getAllByText('Identifiers').length).toBe(1);
+
+    fireEvent.click(pipRow!);
+    expect(getAllByText('Identifiers').length).toBe(1);
+  });
+
+  test('expanded panel shows Brand UUID and Customer UUID labels', () => {
+    const { container, getByText } = render(
+      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+    );
+
+    const aviatoRow = within(container).getByText('Aviato').closest('tr');
+    fireEvent.click(aviatoRow!);
+
+    expect(getByText('Brand UUID:')).toBeDefined();
+    expect(getByText('Customer UUID:')).toBeDefined();
+  });
+
+  test('Challenges renders ordered prompts as "<type> (<lowercase prompt>)"', () => {
+    const { container, getByText } = render(
+      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+    );
+
+    const aviatoRow = within(container).getByText('Aviato').closest('tr');
+    fireEvent.click(aviatoRow!);
+
+    expect(getByText('Birth Date (always)')).toBeDefined();
+    expect(getByText('First Name (if necessary)')).toBeDefined();
+  });
+
+  test('Pied Piper has no providers — only 1-Click Signup column with empty challenges', () => {
+    const { container, getByText, queryByText, getAllByText } = render(
+      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+    );
+
+    const pipRow = within(container).getByText('Pied Piper').closest('tr');
+    fireEvent.click(pipRow!);
+
+    expect(getByText('1-Click Signup')).toBeDefined();
+    expect(queryByText('1-Click Health')).toBeNull();
+    // Empty challenge prompts collapse to "None configured".
+    expect(getAllByText('None configured').length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('Provider names render verbatim (formatting is the backend\'s job)', () => {
+    const { container, getByText } = render(
+      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+    );
+
+    const aviatoRow = within(container).getByText('Aviato').closest('tr');
+    fireEvent.click(aviatoRow!);
+
+    expect(getByText('Acme')).toBeDefined();
+    expect(getByText('Pied Piper')).toBeDefined();
+    expect(getByText('Acme Health')).toBeDefined();
+    expect(getByText('Aviato')).toBeDefined();
+  });
+
+  test('1-Click Health uses an ordered list when mode is fallback', () => {
+    const { container } = render(
+      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+    );
+
+    const aviatoRow = within(container).getByText('Aviato').closest('tr');
+    fireEvent.click(aviatoRow!);
+
+    const expandedPanelRow = aviatoRow?.nextElementSibling;
+    expect(expandedPanelRow?.querySelectorAll('ol').length ?? 0).toBeGreaterThan(0);
+  });
+
+  test('1-Click Health uses an unordered list when mode is parallel', () => {
+    const parallelData = baseData.map((row) =>
+      row.providers?.healthDataProviders
+        ? {
+            ...row,
+            providers: { ...row.providers, healthDataProviderMode: 'parallel' },
+          }
+        : row,
+    );
+    const { container } = render(
+      <BillableEventsTable
+        data={parallelData}
+        isLoading={false}
+        isFetching={false}
+      />,
+    );
+
+    const aviatoRow = within(container).getByText('Aviato').closest('tr');
+    fireEvent.click(aviatoRow!);
+
+    const expandedPanelRow = aviatoRow?.nextElementSibling;
+    // 1-Click Signup is still <ol>; 1-Click Health switches to <ul> for parallel.
+    expect(expandedPanelRow?.querySelectorAll('ul').length ?? 0).toBeGreaterThan(0);
+  });
+
+  test('inner CopyableUuid click does not toggle the row', () => {
+    const { queryByText, getAllByLabelText, container } = render(
+      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+    );
+
+    const aviatoRow = within(container).getByText('Aviato').closest('tr');
+    fireEvent.click(aviatoRow!);
+    // Now expanded — clicking a UUID copy button inside the panel must not
+    // collapse the row.
+    const copyButtons = getAllByLabelText('Copy Brand UUID');
+    fireEvent.click(copyButtons[0]);
+
+    // Panel still open.
+    expect(queryByText('Identifiers')).not.toBeNull();
+  });
+});
+
+describe('exportBillableEventsToCsv', () => {
+  let capturedBlob: Blob | null;
+
+  beforeEach(() => {
+    capturedBlob = null;
+
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn().mockImplementation((blob: Blob) => {
+        capturedBlob = blob;
+        return 'blob:mock';
+      }),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+
+    const realCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation(((tag: string) => {
+      const el = realCreateElement(tag);
+      if (tag === 'a') {
+        Object.defineProperty(el, 'click', { value: vi.fn() });
+      }
+      return el;
+    }) as typeof document.createElement);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('header includes Customer Name + Customer UUID + Brand Name + Brand UUID + Integration Type', async () => {
+    exportBillableEventsToCsv({
+      data: baseData,
+      filename: 'test',
+      visibleProducts: [BillableProduct.ONE_CLICK_SIGNUP],
+    });
+
+    expect(capturedBlob).not.toBeNull();
+    const text = await capturedBlob!.text();
+    const lines = text.split('\n');
+
+    // Row 0: product group header — 5 leading empty cells for the fixed columns.
+    expect(lines[0].startsWith(',,,,,')).toBe(true);
+    // Row 1: column header.
+    expect(lines[1].startsWith(
+      'Customer Name,Customer UUID,Brand Name,Brand UUID,Integration Type',
+    )).toBe(true);
+    // Row 2+: data rows include both customer columns.
+    expect(
+      lines.slice(2).some((l) =>
+        l.startsWith(`Hooli,${HOOLI_CUSTOMER},Aviato,aviato-uuid,SDK`),
+      ),
+    ).toBe(true);
+  });
+});

--- a/tests/components/chart/BillableEventsTable.test.tsx
+++ b/tests/components/chart/BillableEventsTable.test.tsx
@@ -23,7 +23,9 @@ function makeRow(
     integrationType: has('integrationType')
       ? overrides.integrationType!
       : 'SDK',
-    metrics: has('metrics') ? overrides.metrics! : { signup_autofillsSucceeded: 1 },
+    metrics: has('metrics')
+      ? overrides.metrics!
+      : { signup_autofillsSucceeded: 1 },
     raw: has('raw')
       ? overrides.raw!
       : {
@@ -67,7 +69,11 @@ afterEach(() => {
 describe('<BillableEventsTable/>', () => {
   test('Brand UUID column is no longer in the header', () => {
     const { queryByText } = render(
-      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+      <BillableEventsTable
+        data={baseData}
+        isLoading={false}
+        isFetching={false}
+      />,
     );
     // Header used to read 'Brand UUID', lives in the expanded panel only.
     expect(queryByText('Brand UUID:')).toBeNull();
@@ -75,7 +81,11 @@ describe('<BillableEventsTable/>', () => {
 
   test('renders Customer Name column with values', () => {
     const { getByText, getAllByText } = render(
-      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+      <BillableEventsTable
+        data={baseData}
+        isLoading={false}
+        isFetching={false}
+      />,
     );
     expect(getByText('Customer Name')).toBeDefined();
     expect(getByText('Hooli')).toBeDefined();
@@ -101,7 +111,11 @@ describe('<BillableEventsTable/>', () => {
 
   test('sort by Customer Name (asc then desc)', () => {
     const { getByText, container } = render(
-      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+      <BillableEventsTable
+        data={baseData}
+        isLoading={false}
+        isFetching={false}
+      />,
     );
 
     fireEvent.click(getByText('Customer Name'));
@@ -110,14 +124,17 @@ describe('<BillableEventsTable/>', () => {
     expect(firstRowText).toContain('Hooli');
 
     fireEvent.click(getByText('Customer Name'));
-    firstRowText =
-      container.querySelectorAll('tbody tr')[0]?.textContent ?? '';
+    firstRowText = container.querySelectorAll('tbody tr')[0]?.textContent ?? '';
     expect(firstRowText).toContain('Pied Piper');
   });
 
   test('whole-row click toggles the panel', () => {
     const { queryByText, getByText, getAllByText } = render(
-      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+      <BillableEventsTable
+        data={baseData}
+        isLoading={false}
+        isFetching={false}
+      />,
     );
 
     expect(queryByText('Identifiers')).toBeNull();
@@ -135,7 +152,11 @@ describe('<BillableEventsTable/>', () => {
 
   test('only one row is expanded at a time', () => {
     const { getAllByText } = render(
-      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+      <BillableEventsTable
+        data={baseData}
+        isLoading={false}
+        isFetching={false}
+      />,
     );
 
     const aviatoRow = getAllByText('Aviato')[0].closest('tr');
@@ -150,7 +171,11 @@ describe('<BillableEventsTable/>', () => {
 
   test('expanded panel shows Brand UUID and Customer UUID labels', () => {
     const { getByText, getAllByText } = render(
-      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+      <BillableEventsTable
+        data={baseData}
+        isLoading={false}
+        isFetching={false}
+      />,
     );
 
     const aviatoRow = getAllByText('Aviato')[0].closest('tr');
@@ -162,7 +187,11 @@ describe('<BillableEventsTable/>', () => {
 
   test('Challenges renders ordered prompts as "<type> (<lowercase prompt>)"', () => {
     const { getByText, getAllByText } = render(
-      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+      <BillableEventsTable
+        data={baseData}
+        isLoading={false}
+        isFetching={false}
+      />,
     );
 
     const aviatoRow = getAllByText('Aviato')[0].closest('tr');
@@ -174,7 +203,11 @@ describe('<BillableEventsTable/>', () => {
 
   test('Pied Piper has no providers — only 1-Click Signup column with empty challenges', () => {
     const { getAllByText } = render(
-      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+      <BillableEventsTable
+        data={baseData}
+        isLoading={false}
+        isFetching={false}
+      />,
     );
 
     const pipRow = getAllByText('Pied Piper')[0].closest('tr');
@@ -186,12 +219,18 @@ describe('<BillableEventsTable/>', () => {
     expect(panel.getByText('1-Click Signup')).toBeDefined();
     expect(panel.queryByText('1-Click Health')).toBeNull();
     // Empty challenge prompts collapse to "None configured".
-    expect(panel.getAllByText('None configured').length).toBeGreaterThanOrEqual(1);
+    expect(panel.getAllByText('None configured').length).toBeGreaterThanOrEqual(
+      1,
+    );
   });
 
-  test('Provider names render verbatim (formatting is the backend\'s job)', () => {
+  test("Provider names render verbatim (formatting is the backend's job)", () => {
     const { getAllByText } = render(
-      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+      <BillableEventsTable
+        data={baseData}
+        isLoading={false}
+        isFetching={false}
+      />,
     );
 
     const aviatoRow = getAllByText('Aviato')[0].closest('tr');
@@ -210,14 +249,20 @@ describe('<BillableEventsTable/>', () => {
 
   test('1-Click Health uses an ordered list when mode is fallback', () => {
     const { getAllByText } = render(
-      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+      <BillableEventsTable
+        data={baseData}
+        isLoading={false}
+        isFetching={false}
+      />,
     );
 
     const aviatoRow = getAllByText('Aviato')[0].closest('tr');
     fireEvent.click(aviatoRow!);
 
     const expandedPanelRow = aviatoRow?.nextElementSibling;
-    expect(expandedPanelRow?.querySelectorAll('ol').length ?? 0).toBeGreaterThan(0);
+    expect(
+      expandedPanelRow?.querySelectorAll('ol').length ?? 0,
+    ).toBeGreaterThan(0);
   });
 
   test('1-Click Health uses an unordered list when mode is parallel', () => {
@@ -242,12 +287,18 @@ describe('<BillableEventsTable/>', () => {
 
     const expandedPanelRow = aviatoRow?.nextElementSibling;
     // 1-Click Signup is still <ol>; 1-Click Health switches to <ul> for parallel.
-    expect(expandedPanelRow?.querySelectorAll('ul').length ?? 0).toBeGreaterThan(0);
+    expect(
+      expandedPanelRow?.querySelectorAll('ul').length ?? 0,
+    ).toBeGreaterThan(0);
   });
 
   test('inner CopyableUuid click does not toggle the row', () => {
     const { queryByText, getAllByLabelText, getAllByText } = render(
-      <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
+      <BillableEventsTable
+        data={baseData}
+        isLoading={false}
+        isFetching={false}
+      />,
     );
 
     const aviatoRow = getAllByText('Aviato')[0].closest('tr');
@@ -314,14 +365,18 @@ describe('exportBillableEventsToCsv', () => {
     // Row 0: product group header, 5 leading empty cells for the fixed columns.
     expect(lines[0].startsWith(',,,,,')).toBe(true);
     // Row 1: column header.
-    expect(lines[1].startsWith(
-      'Customer Name,Customer UUID,Brand Name,Brand UUID,Integration Type',
-    )).toBe(true);
+    expect(
+      lines[1].startsWith(
+        'Customer Name,Customer UUID,Brand Name,Brand UUID,Integration Type',
+      ),
+    ).toBe(true);
     // Row 2+: data rows include both customer columns.
     expect(
-      lines.slice(2).some((l) =>
-        l.startsWith(`Hooli,${HOOLI_CUSTOMER},Aviato,aviato-uuid,SDK`),
-      ),
+      lines
+        .slice(2)
+        .some((l) =>
+          l.startsWith(`Hooli,${HOOLI_CUSTOMER},Aviato,aviato-uuid,SDK`),
+        ),
     ).toBe(true);
   });
 });

--- a/tests/components/chart/BillableEventsTable.test.tsx
+++ b/tests/components/chart/BillableEventsTable.test.tsx
@@ -14,18 +14,23 @@ const PIED_PIPER_CUSTOMER = 'a0000000-0000-0000-0000-000000000002';
 function makeRow(
   overrides: Partial<BillableEventsTableRow>,
 ): BillableEventsTableRow {
+  const has = (key: keyof BillableEventsTableRow) => key in overrides;
   return {
-    brandUuid: overrides.brandUuid ?? 'brand-1',
-    brand: overrides.brand ?? 'Brand 1',
-    customerUuid: overrides.customerUuid ?? HOOLI_CUSTOMER,
-    customerName: overrides.customerName ?? 'Hooli',
-    integrationType: overrides.integrationType ?? 'SDK',
-    metrics: overrides.metrics ?? { signup_autofillsSucceeded: 1 },
-    raw: overrides.raw ?? {
-      brandUuid: overrides.brandUuid ?? 'brand-1',
-      brandName: overrides.brand ?? 'Brand 1',
-      overall: {},
-    },
+    brandUuid: has('brandUuid') ? overrides.brandUuid! : 'brand-1',
+    brand: has('brand') ? overrides.brand! : 'Brand 1',
+    customerUuid: has('customerUuid') ? overrides.customerUuid : HOOLI_CUSTOMER,
+    customerName: has('customerName') ? overrides.customerName : 'Hooli',
+    integrationType: has('integrationType')
+      ? overrides.integrationType!
+      : 'SDK',
+    metrics: has('metrics') ? overrides.metrics! : { signup_autofillsSucceeded: 1 },
+    raw: has('raw')
+      ? overrides.raw!
+      : {
+          brandUuid: overrides.brandUuid ?? 'brand-1',
+          brandName: overrides.brand ?? 'Brand 1',
+          overall: {},
+        },
     challengePrompts: overrides.challengePrompts,
     providers: overrides.providers,
   };
@@ -64,17 +69,19 @@ describe('<BillableEventsTable/>', () => {
     const { queryByText } = render(
       <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
     );
-    // Header used to read 'Brand UUID' — now lives in the expanded panel only.
+    // Header used to read 'Brand UUID', lives in the expanded panel only.
     expect(queryByText('Brand UUID:')).toBeNull();
   });
 
   test('renders Customer Name column with values', () => {
-    const { getByText } = render(
+    const { getByText, getAllByText } = render(
       <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
     );
     expect(getByText('Customer Name')).toBeDefined();
     expect(getByText('Hooli')).toBeDefined();
-    expect(getByText('Pied Piper')).toBeDefined();
+    // 'Pied Piper' is both the customer name AND the brand name,
+    // so it appears in two cells of the same row.
+    expect(getAllByText('Pied Piper').length).toBeGreaterThanOrEqual(2);
   });
 
   test('renders em-dash placeholder when customerName is missing', () => {
@@ -109,13 +116,13 @@ describe('<BillableEventsTable/>', () => {
   });
 
   test('whole-row click toggles the panel', () => {
-    const { container, queryByText, getByText } = render(
+    const { queryByText, getByText, getAllByText } = render(
       <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
     );
 
     expect(queryByText('Identifiers')).toBeNull();
 
-    const aviatoRow = within(container).getByText('Aviato').closest('tr');
+    const aviatoRow = getAllByText('Aviato')[0].closest('tr');
     expect(aviatoRow).not.toBeNull();
     fireEvent.click(aviatoRow!);
 
@@ -127,12 +134,12 @@ describe('<BillableEventsTable/>', () => {
   });
 
   test('only one row is expanded at a time', () => {
-    const { container, getAllByText } = render(
+    const { getAllByText } = render(
       <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
     );
 
-    const aviatoRow = within(container).getByText('Aviato').closest('tr');
-    const pipRow = within(container).getByText('Pied Piper').closest('tr');
+    const aviatoRow = getAllByText('Aviato')[0].closest('tr');
+    const pipRow = getAllByText('Pied Piper')[0].closest('tr');
 
     fireEvent.click(aviatoRow!);
     expect(getAllByText('Identifiers').length).toBe(1);
@@ -142,11 +149,11 @@ describe('<BillableEventsTable/>', () => {
   });
 
   test('expanded panel shows Brand UUID and Customer UUID labels', () => {
-    const { container, getByText } = render(
+    const { getByText, getAllByText } = render(
       <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
     );
 
-    const aviatoRow = within(container).getByText('Aviato').closest('tr');
+    const aviatoRow = getAllByText('Aviato')[0].closest('tr');
     fireEvent.click(aviatoRow!);
 
     expect(getByText('Brand UUID:')).toBeDefined();
@@ -154,11 +161,11 @@ describe('<BillableEventsTable/>', () => {
   });
 
   test('Challenges renders ordered prompts as "<type> (<lowercase prompt>)"', () => {
-    const { container, getByText } = render(
+    const { getByText, getAllByText } = render(
       <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
     );
 
-    const aviatoRow = within(container).getByText('Aviato').closest('tr');
+    const aviatoRow = getAllByText('Aviato')[0].closest('tr');
     fireEvent.click(aviatoRow!);
 
     expect(getByText('Birth Date (always)')).toBeDefined();
@@ -166,39 +173,47 @@ describe('<BillableEventsTable/>', () => {
   });
 
   test('Pied Piper has no providers — only 1-Click Signup column with empty challenges', () => {
-    const { container, getByText, queryByText, getAllByText } = render(
+    const { getAllByText } = render(
       <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
     );
 
-    const pipRow = within(container).getByText('Pied Piper').closest('tr');
+    const pipRow = getAllByText('Pied Piper')[0].closest('tr');
     fireEvent.click(pipRow!);
 
-    expect(getByText('1-Click Signup')).toBeDefined();
-    expect(queryByText('1-Click Health')).toBeNull();
+    const expandedPanelRow = pipRow?.nextElementSibling as HTMLElement;
+    const panel = within(expandedPanelRow);
+
+    expect(panel.getByText('1-Click Signup')).toBeDefined();
+    expect(panel.queryByText('1-Click Health')).toBeNull();
     // Empty challenge prompts collapse to "None configured".
-    expect(getAllByText('None configured').length).toBeGreaterThanOrEqual(1);
+    expect(panel.getAllByText('None configured').length).toBeGreaterThanOrEqual(1);
   });
 
   test('Provider names render verbatim (formatting is the backend\'s job)', () => {
-    const { container, getByText } = render(
+    const { getAllByText } = render(
       <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
     );
 
-    const aviatoRow = within(container).getByText('Aviato').closest('tr');
+    const aviatoRow = getAllByText('Aviato')[0].closest('tr');
     fireEvent.click(aviatoRow!);
 
-    expect(getByText('Acme')).toBeDefined();
-    expect(getByText('Pied Piper')).toBeDefined();
-    expect(getByText('Acme Health')).toBeDefined();
-    expect(getByText('Aviato')).toBeDefined();
+    const expandedPanelRow = aviatoRow?.nextElementSibling as HTMLElement;
+    expect(expandedPanelRow).not.toBeNull();
+    const panel = within(expandedPanelRow);
+
+    expect(panel.getByText('Acme')).toBeDefined();
+    expect(panel.getByText('Acme Health')).toBeDefined();
+    // 'Pied Piper' and 'Aviato' are brands and providers; assert at-least-one inside the panel.
+    expect(panel.getAllByText('Pied Piper').length).toBeGreaterThan(0);
+    expect(panel.getAllByText('Aviato').length).toBeGreaterThan(0);
   });
 
   test('1-Click Health uses an ordered list when mode is fallback', () => {
-    const { container } = render(
+    const { getAllByText } = render(
       <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
     );
 
-    const aviatoRow = within(container).getByText('Aviato').closest('tr');
+    const aviatoRow = getAllByText('Aviato')[0].closest('tr');
     fireEvent.click(aviatoRow!);
 
     const expandedPanelRow = aviatoRow?.nextElementSibling;
@@ -214,7 +229,7 @@ describe('<BillableEventsTable/>', () => {
           }
         : row,
     );
-    const { container } = render(
+    const { getAllByText } = render(
       <BillableEventsTable
         data={parallelData}
         isLoading={false}
@@ -222,7 +237,7 @@ describe('<BillableEventsTable/>', () => {
       />,
     );
 
-    const aviatoRow = within(container).getByText('Aviato').closest('tr');
+    const aviatoRow = getAllByText('Aviato')[0].closest('tr');
     fireEvent.click(aviatoRow!);
 
     const expandedPanelRow = aviatoRow?.nextElementSibling;
@@ -231,13 +246,13 @@ describe('<BillableEventsTable/>', () => {
   });
 
   test('inner CopyableUuid click does not toggle the row', () => {
-    const { queryByText, getAllByLabelText, container } = render(
+    const { queryByText, getAllByLabelText, getAllByText } = render(
       <BillableEventsTable data={baseData} isLoading={false} isFetching={false} />,
     );
 
-    const aviatoRow = within(container).getByText('Aviato').closest('tr');
+    const aviatoRow = getAllByText('Aviato')[0].closest('tr');
     fireEvent.click(aviatoRow!);
-    // Now expanded — clicking a UUID copy button inside the panel must not
+    // Clicking a UUID copy button inside the panel must not
     // collapse the row.
     const copyButtons = getAllByLabelText('Copy Brand UUID');
     fireEvent.click(copyButtons[0]);
@@ -287,10 +302,16 @@ describe('exportBillableEventsToCsv', () => {
     });
 
     expect(capturedBlob).not.toBeNull();
-    const text = await capturedBlob!.text();
+    // jsdom's Blob lacks .text(); read via FileReader.
+    const text = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = () => reject(reader.error);
+      reader.readAsText(capturedBlob!);
+    });
     const lines = text.split('\n');
 
-    // Row 0: product group header — 5 leading empty cells for the fixed columns.
+    // Row 0: product group header, 5 leading empty cells for the fixed columns.
     expect(lines[0].startsWith(',,,,,')).toBe(true);
     // Row 1: column header.
     expect(lines[1].startsWith(


### PR DESCRIPTION
## Summary
<!---
1-2 sentences summarizing the changes included in this PR
--->

## Changes
- feat: add BrandDetailsPanel and related formatting functions for challenge prompts and providers
- feat: add BrandDetailsPanel to BillableEventsTable and enhance table row expansion
- feat: enhance CSV export by adding customer details to headers and rows
- feat: add customer details to BillableEventsTable stories and implement related tests
- fix: refactor makeRow function for improved readability and consistency in BillableEventsTable tests

## Testing
- npm run test: 220 passed (220)
- npm run storybook
  - chart > BillableEventsTable
  - click any row > it expands to show identifiers and settings

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [x] Any dependent changes have been merged and published in upstream projects.
