### PR TITLE
feat: add MemberIdInput component with masked input functionality

### DIFF
--- a/src/components/form/MemberIdInput/index.tsx
+++ b/src/components/form/MemberIdInput/index.tsx
@@ -8,6 +8,8 @@ import {
 } from '@mui/material';
 import { Visibility, VisibilityOff } from '@mui/icons-material';
 
+import { buildDisplayValue } from './utils';
+
 export type MemberIdInputProps = Omit<TextFieldProps, 'onChange'> & {
   onChange?: (event: { target: { value: string } }) => void;
   name?: string;
@@ -20,16 +22,6 @@ export type MemberIdInputProps = Omit<TextFieldProps, 'onChange'> & {
 
 function isRedactedValue(value: string): boolean {
   return value.includes('*') || value.includes('•');
-}
-
-// Normalize * → • then apply centered masking for display.
-function buildDisplayValue(value: string): string {
-  const normalized = value.replace(/\*/g, '•');
-  if (normalized.includes('•')) return normalized;
-  const length = normalized.length;
-  if (length <= 2) return normalized;
-  if (length < 5) return '•'.repeat(length - 2) + normalized.slice(-2);
-  return normalized.slice(0, 2) + '•'.repeat(length - 4) + normalized.slice(-2);
 }
 
 /**
@@ -74,9 +66,10 @@ export function MemberIdInput({
         value={displayValue}
         placeholder={placeholder}
         onChange={(e) => {
-          // When visible, pass through directly — no masking logic needed.
+          // When visible, pass through directly — only strip redaction chars
+          // so a paste of "••••AC02" doesn't get accepted as raw.
           if (isVisible) {
-            propagate(e.target.value);
+            propagate(e.target.value.replace(/[•*]/g, ''));
             return;
           }
 
@@ -87,9 +80,9 @@ export function MemberIdInput({
 
           if (!isActivelyTyping) {
             // Pre-filled/redacted — only reachable via paste or autofill since
-            // regular keystrokes are intercepted in onKeyDown. Strip display
-            // dots and treat the result as a fresh value.
-            propagate(newDisplay.replace(/•/g, ''));
+            // regular keystrokes are intercepted in onKeyDown. Strip redaction
+            // chars and treat the result as a fresh value.
+            propagate(newDisplay.replace(/[•*]/g, ''));
             return;
           }
 
@@ -102,7 +95,7 @@ export function MemberIdInput({
             );
             newRaw =
               prevRaw.slice(0, pos) +
-              inserted.replace(/•/g, '') +
+              inserted.replace(/[•*]/g, '') +
               prevRaw.slice(pos);
           } else if (newDisplay.length < prevDisplay.length) {
             // Deletion via cut / drag-drop (keyboard backspace is handled below).
@@ -113,7 +106,8 @@ export function MemberIdInput({
           } else {
             // Same length: overwrite at cursor position.
             const newChar = newDisplay[pos] ?? '';
-            newRaw = prevRaw.slice(0, pos) + newChar + prevRaw.slice(pos + 1);
+            const sanitized = newChar.replace(/[•*]/g, '');
+            newRaw = prevRaw.slice(0, pos) + sanitized + prevRaw.slice(pos + 1);
           }
 
           propagate(newRaw);
@@ -143,7 +137,7 @@ export function MemberIdInput({
             // Pre-filled or redacted: start fresh with the typed char.
             if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
               e.preventDefault();
-              propagate(e.key);
+              if (e.key !== '*' && e.key !== '•') propagate(e.key);
             }
           },
         }}

--- a/src/components/form/MemberIdInput/index.tsx
+++ b/src/components/form/MemberIdInput/index.tsx
@@ -25,7 +25,7 @@ function isRedactedValue(value: string): boolean {
 }
 
 /**
- * Masked input for member IDs. Displays the middle characters as bullets.
+ * Masked input for member IDs. show last 4 via buildDisplayValue.
  * - Pre-filled / redacted values: any keystroke starts fresh; backspace clears.
  * - User-typed values: normal editing; backspace always clears the whole field.
  */

--- a/src/components/form/MemberIdInput/utils.ts
+++ b/src/components/form/MemberIdInput/utils.ts
@@ -1,0 +1,16 @@
+// Normalize * → • then apply last-4 masking for display.
+export function buildDisplayValue(value: string): string {
+  const normalized = value.replace(/\*/g, '•');
+  if (normalized.includes('•')) {
+    // Server may use an old format (e.g. "21••••••••13") that exposes chars at both ends.
+    // Re-mask so only the trailing visible chars are shown, everything else is a bullet.
+    const lastBulletIdx = normalized.lastIndexOf('•');
+    const trailingVisible = normalized.slice(lastBulletIdx + 1);
+    return (
+      '•'.repeat(normalized.length - trailingVisible.length) + trailingVisible
+    );
+  }
+  const length = normalized.length;
+  if (length <= 4) return normalized;
+  return '•'.repeat(length - 4) + normalized.slice(-4);
+}

--- a/src/stories/components/form/CredentialForm.stories.tsx
+++ b/src/stories/components/form/CredentialForm.stories.tsx
@@ -554,7 +554,7 @@ const mockCredentials = [
     type: 'healthInsurance',
     value: {
       id: 174,
-      memberId: 'AC****02',
+      memberId: '****AC02',
       payer: {
         verifiedId: 'V123123',
         name: 'Aviato Health Insurance Of California',

--- a/tests/components/form/MemberIdInput/utils.test.ts
+++ b/tests/components/form/MemberIdInput/utils.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildDisplayValue } from '../../../../src/components/form/MemberIdInput/utils';
+
+describe('buildDisplayValue', () => {
+  describe('short values (≤4 chars) — no masking', () => {
+    it('returns 1-char value unchanged', () => {
+      expect(buildDisplayValue('A')).toBe('A');
+    });
+
+    it('returns 2-char value unchanged', () => {
+      expect(buildDisplayValue('AB')).toBe('AB');
+    });
+
+    it('returns 3-char value unchanged', () => {
+      expect(buildDisplayValue('ABC')).toBe('ABC');
+    });
+
+    it('returns 4-char value unchanged', () => {
+      expect(buildDisplayValue('ABCD')).toBe('ABCD');
+    });
+  });
+
+  describe('longer values — masks all but last 4', () => {
+    it('masks 1 char for a 5-char value', () => {
+      expect(buildDisplayValue('ABCDE')).toBe('•BCDE');
+    });
+
+    it('masks 2 chars for a 6-char value', () => {
+      expect(buildDisplayValue('ABCDEF')).toBe('••CDEF');
+    });
+
+    it('masks 3 chars for a 7-char value', () => {
+      expect(buildDisplayValue('ABCDEFG')).toBe('•••DEFG');
+    });
+
+    it('masks all but last 4 for a 12-char value', () => {
+      expect(buildDisplayValue('ABCDEFGHIJKL')).toBe('••••••••IJKL');
+    });
+
+    it('preserves numeric characters', () => {
+      expect(buildDisplayValue('123456789')).toBe('•••••6789');
+    });
+
+    it('preserves alphanumeric mix', () => {
+      expect(buildDisplayValue('XYZ123456789')).toBe('••••••••6789');
+    });
+  });
+
+  describe('server-redacted values (already contain • or *)', () => {
+    it('returns a value already in last-4 format unchanged', () => {
+      expect(buildDisplayValue('••••5678')).toBe('••••5678');
+    });
+
+    it('normalizes * to • for a value already in last-4 format', () => {
+      expect(buildDisplayValue('****5678')).toBe('••••5678');
+    });
+
+    it('normalizes mixed * and •', () => {
+      expect(buildDisplayValue('**••5678')).toBe('••••5678');
+    });
+
+    it('re-masks old server format (first-2 + last-2) to last-visible-only', () => {
+      // Server sends "21••••••••13" — strip leading visible chars, keep trailing.
+      expect(buildDisplayValue('21••••••••13')).toBe('••••••••••13');
+    });
+
+    it('re-masks old server format with * characters', () => {
+      expect(buildDisplayValue('21********13')).toBe('••••••••••13');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty string unchanged', () => {
+      expect(buildDisplayValue('')).toBe('');
+    });
+
+    it('handles exactly 4 chars with no masking', () => {
+      expect(buildDisplayValue('1234')).toBe('1234');
+    });
+
+    it('masks length is preserved (display length equals input length)', () => {
+      const input = 'ABCDEFGHIJ'; // 10 chars
+      const display = buildDisplayValue(input);
+      expect(display.length).toBe(input.length);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Updates `MemberIdInput` masking to show only the last 4 characters (e.g. `••••AC02`) instead of the previous first-2 + last-2 pattern, and re-masks legacy server-redacted values that still expose leading characters.

## Changes
- Extract `buildDisplayValue` into `MemberIdInput/utils.ts` and switch to last-4 masking; values ≤4 chars remain unmasked.
- Re-mask server values that arrive in the old `21••••••••13` format so leading characters are also hidden.
- Strip `•`/`*` from pasted, typed, and overwrite input paths so redaction glyphs can never be propagated as raw value.
- Update `CredentialForm` story mock from `'AC****02'` to `'****AC02'` to match the new mask pattern.
- Add unit tests for `buildDisplayValue` covering short values, long values, server-redacted inputs, and edge cases.

## Testing
- `npm test` — new `tests/components/form/MemberIdInput/utils.test.ts` covers short/long values, `*`/`•` normalization, legacy server format re-masking, and length-preservation.
- Manually verify in Storybook (`CredentialForm` story): the pre-filled `****AC02` renders as `••••AC02`; typing replaces the value cleanly; pasting a string containing `•` or `*` strips those characters before propagation.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [x] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
