### PR TITLE
fix: optimize field update logic in FormProvider for React 18 StrictMode compatibility

### DIFF
--- a/src/components/form/NewOneClickForm/react/core/form.context.tsx
+++ b/src/components/form/NewOneClickForm/react/core/form.context.tsx
@@ -180,36 +180,25 @@ export const FormProvider: React.FC<FormProviderProps> = ({
 
   const updateFieldValue = useCallback(
     (path: string, value: any) => {
+      // Equality check and field lookup happen OUTSIDE setState so they are not
+      // re-executed by React 18 StrictMode's double-invocation of updaters.
+      // Mutating FormField inside the updater AND bailing out via `return prev`
+      // makes the updater impure: on the second invocation the mutation from
+      // the first invocation makes the equality check pass, returning `prev`
+      // and dropping the state update, which loses keystrokes.
+      const field = getField(path);
+      if (!field) {
+        console.warn(`Attempted to update non-existent field: ${path}`);
+        return;
+      }
+      if (field.value === value) return;
+
+      field.value = value;
+      updateParentFieldsRecursively(path);
+
       setState((prev) => {
-        if (!prev.form) {
-          console.warn('No form instance available');
-          return prev;
-        }
-
-        // Use the enhanced getField function to find the field by path
-        const field = getField(path);
-
-        if (!field) {
-          console.warn(`Attempted to update non-existent field: ${path}`);
-          return prev;
-        }
-
-        // Check if value actually changed to avoid unnecessary updates
-        if (field.value === value) {
-          return prev;
-        }
-
-        // Update the field value directly on the core FormField instance
-        field.value = value;
-
-        // Recursively update all parent composite fields up the hierarchy
-        updateParentFieldsRecursively(path);
-
-        // Force re-render by creating new state object
-        return {
-          ...prev,
-          form: prev.form, // This will trigger re-render due to field mutation
-        };
+        if (!prev.form) return prev;
+        return { ...prev, form: prev.form };
       });
     },
     [getField, updateParentFieldsRecursively],
@@ -217,35 +206,22 @@ export const FormProvider: React.FC<FormProviderProps> = ({
 
   const setFieldTouched = useCallback(
     (path: string, touched: boolean) => {
+      // Same StrictMode-safety rationale as updateFieldValue: do the equality
+      // check and mutation outside setState so the updater stays pure.
+      const field = getField(path);
+      if (!field) {
+        console.warn(
+          `Attempted to set touched state for non-existent field: ${path}`,
+        );
+        return;
+      }
+      if (field.touched === touched) return;
+
+      field.touched = touched;
+
       setState((prev) => {
-        if (!prev.form) {
-          console.warn('No form instance available');
-          return prev;
-        }
-
-        // Use the enhanced getField function to find the field by path
-        const field = getField(path);
-
-        if (!field) {
-          console.warn(
-            `Attempted to set touched state for non-existent field: ${path}`,
-          );
-          return prev;
-        }
-
-        // Avoid unnecessary updates if touched state hasn't changed
-        if (field.touched === touched) {
-          return prev;
-        }
-
-        // Update the field touched state directly on the core FormField instance
-        field.touched = touched;
-
-        // Force re-render by creating new state object
-        return {
-          ...prev,
-          form: prev.form, // This will trigger re-render due to field mutation
-        };
+        if (!prev.form) return prev;
+        return { ...prev, form: prev.form };
       });
     },
     [getField],


### PR DESCRIPTION
## Summary
Fixes lost keystrokes in `NewOneClickForm` by making `updateFieldValue` and `setFieldTouched` updaters pure, so React 18 StrictMode's double-invocation of state updaters no longer drops updates.

## Changes
- `form.context.tsx`: Move field lookup, equality check, and `FormField` mutation **outside** the `setState` updater in `updateFieldValue` and `setFieldTouched`. The updater now only returns a new state reference to trigger a re-render.
- Reason: mutating the `FormField` inside the updater and bailing out via `return prev` made the updater impure — on StrictMode's second invocation the equality check passed against the already-mutated field, returning `prev` and dropping the state update.

## Testing
- Type new characters quickly into a One-Click form field in React 18 StrictMode and confirm no keystrokes are lost.
- Verify field touched state still updates correctly on blur.
- Confirm parent composite fields still update via `updateParentFieldsRecursively`.
- Run existing Vitest suite for `NewOneClickForm` / `FormProvider`.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
