### PR TITLE
feat/iso date field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verifiedinc-public/shared-ui-elements",
-  "version": "9.13.0",
+  "version": "9.13.0-local123321",
   "description": "A set of UI components, utilities that is shareable with the core apps.",
   "private": false,
   "sideEffects": false,

--- a/src/components/form/NewOneClickForm/core/formats/date.format.ts
+++ b/src/components/form/NewOneClickForm/core/formats/date.format.ts
@@ -1,5 +1,20 @@
+const MASKED_YEAR_REGEX = /^•{4}-(\d{2})-(\d{2})$/;
+const ISO_DATE_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/;
+
 export const dateFormat = (value: string) => {
-  // Format as MM/DD/YYYY in UTC
+  // Server-masked birthDate: ••••-MM-DD → MM/DD/••••
+  const maskedMatch = MASKED_YEAR_REGEX.exec(value);
+  if (maskedMatch) {
+    return `${maskedMatch[1]}/${maskedMatch[2]}/••••`;
+  }
+
+  // ISO date string: YYYY-MM-DD → MM/DD/YYYY
+  const isoMatch = ISO_DATE_REGEX.exec(value);
+  if (isoMatch) {
+    return `${isoMatch[2]}/${isoMatch[3]}/${isoMatch[1]}`;
+  }
+
+  // Legacy Unix-ms timestamp → MM/DD/YYYY (UTC)
   const date = new Date(Number(value));
   const month = String(date.getUTCMonth() + 1).padStart(2, '0');
   const day = String(date.getUTCDate()).padStart(2, '0');

--- a/src/components/form/NewOneClickForm/react/ui/fields/input/date.field.tsx
+++ b/src/components/form/NewOneClickForm/react/ui/fields/input/date.field.tsx
@@ -1,7 +1,10 @@
 import { useRef, useState } from 'react';
 import { Box } from '@mui/material';
 
-import { USDateSchema, validateTimestamp } from '../../../../../../../validations/date.schema';
+import {
+  USDateSchema,
+  validateTimestamp,
+} from '../../../../../../../validations/date.schema';
 import { formatDateMMDDYYYY } from '../../../../../../../utils/date';
 
 import { DateInput } from '../../../../../../form';
@@ -21,9 +24,13 @@ export function DateInputField({ fieldKey }: { fieldKey: string }) {
   const { options } = useOneClickForm();
   const { field, setValue } = useFormField<'birthDate'>({ key: fieldKey });
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const isServerMasked = /^•{4}-\d{2}-\d{2}$/.test((field?.value as string) ?? '');
+  const isServerMasked = /^•{4}-\d{2}-\d{2}$/.test(
+    (field?.value as string) ?? '',
+  );
   // If the original credential was stored as a Unix-ms timestamp, preserve that format on change
-  const useLegacyTimestamp = validateTimestamp((field?.defaultValue as string) ?? '');
+  const useLegacyTimestamp = validateTimestamp(
+    (field?.defaultValue as string) ?? '',
+  );
 
   const [localValue, setLocalValue] = useState<string>(() => {
     const value = field?.value as string | undefined;
@@ -95,7 +102,9 @@ export function DateInputField({ fieldKey }: { fieldKey: string }) {
       // Preserve Unix-ms timestamp format for credentials that originally used it
       setValue(String(Date.UTC(year, month - 1, day, 12, 0, 0, 0)));
     } else {
-      setValue(`${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`);
+      setValue(
+        `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`,
+      );
     }
   };
 
@@ -126,7 +135,9 @@ export function DateInputField({ fieldKey }: { fieldKey: string }) {
         minDate={minDateForPicker}
         maxDate={maxDateForPicker}
         disabled={field.isDisabled}
-        redactYear={isServerMasked || (isDob && options.features.field?.dob?.redactYear)}
+        redactYear={
+          isServerMasked || (isDob && options.features.field?.dob?.redactYear)
+        }
         InputProps={{
           'data-mask-me': true,
           endAdornment: (

--- a/src/components/form/NewOneClickForm/react/ui/fields/input/date.field.tsx
+++ b/src/components/form/NewOneClickForm/react/ui/fields/input/date.field.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react';
 import { Box } from '@mui/material';
 
-import { USDateSchema } from '../../../../../../../validations/date.schema';
+import { USDateSchema, validateTimestamp } from '../../../../../../../validations/date.schema';
 import { formatDateMMDDYYYY } from '../../../../../../../utils/date';
 
 import { DateInput } from '../../../../../../form';
@@ -21,9 +21,22 @@ export function DateInputField({ fieldKey }: { fieldKey: string }) {
   const { options } = useOneClickForm();
   const { field, setValue } = useFormField<'birthDate'>({ key: fieldKey });
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const [localValue, setLocalValue] = useState<string>(
-    field?.value ? formatDateMMDDYYYY(field?.value) : '',
-  );
+  const isServerMasked = /^•{4}-\d{2}-\d{2}$/.test((field?.value as string) ?? '');
+  // If the original credential was stored as a Unix-ms timestamp, preserve that format on change
+  const useLegacyTimestamp = validateTimestamp((field?.defaultValue as string) ?? '');
+
+  const [localValue, setLocalValue] = useState<string>(() => {
+    const value = field?.value as string | undefined;
+    if (!value) return '';
+    // Server-masked birthDate (••••-MM-DD): show MM/DD with fake year so redactYear renders ••••
+    const maskedMatch = /^•{4}-(\d{2})-(\d{2})$/.exec(value);
+    if (maskedMatch) return `${maskedMatch[1]}/${maskedMatch[2]}/1900`;
+    // ISO date string (YYYY-MM-DD): convert to MM/DD/YYYY for the input
+    const isoMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+    if (isoMatch) return `${isoMatch[2]}/${isoMatch[3]}/${isoMatch[1]}`;
+    // Legacy Unix-ms timestamp
+    return formatDateMMDDYYYY(value);
+  });
 
   if (
     !field ||
@@ -55,6 +68,13 @@ export function DateInputField({ fieldKey }: { fieldKey: string }) {
   const handleChange = (value: string) => {
     if (field.isDisabled) return;
 
+    // Any edit to a server-masked field must start fresh — the fake year must never be saved
+    if (isServerMasked) {
+      setLocalValue('');
+      setValue('');
+      return;
+    }
+
     const valid = USDateSchema.safeParse(value);
     const valueParsed = value.replace(/[^0-9]/g, '');
 
@@ -69,11 +89,14 @@ export function DateInputField({ fieldKey }: { fieldKey: string }) {
       return setValue('NaN');
     }
 
-    // Parse the date string (MM/DD/YYYY) and create a UTC date
     const [month, day, year] = value.split('/').map(Number);
-    const dateTimestamp = Date.UTC(year, month - 1, day, 12, 0, 0, 0);
 
-    setValue(String(dateTimestamp));
+    if (useLegacyTimestamp) {
+      // Preserve Unix-ms timestamp format for credentials that originally used it
+      setValue(String(Date.UTC(year, month - 1, day, 12, 0, 0, 0)));
+    } else {
+      setValue(`${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`);
+    }
   };
 
   const handleClear = () => {
@@ -103,7 +126,7 @@ export function DateInputField({ fieldKey }: { fieldKey: string }) {
         minDate={minDateForPicker}
         maxDate={maxDateForPicker}
         disabled={field.isDisabled}
-        redactYear={isDob && options.features.field?.dob?.redactYear}
+        redactYear={isServerMasked || (isDob && options.features.field?.dob?.redactYear)}
         InputProps={{
           'data-mask-me': true,
           endAdornment: (

--- a/src/stories/components/form/CredentialForm.stories.tsx
+++ b/src/stories/components/form/CredentialForm.stories.tsx
@@ -510,7 +510,7 @@ const mockCredentials = [
     uuid: 'dob-id-1234',
     type: 'birthDate',
     value: {
-      birthDate: '617976000000',
+      birthDate: '1989-08-01',
     },
   },
   {
@@ -519,8 +519,8 @@ const mockCredentials = [
     value: {
       documentNumber: '123456789',
       issuanceState: 'NY',
-      issuanceDate: '1754049600000',
-      expirationDate: '1765800000000',
+      issuanceDate: '2025-08-01',
+      expirationDate: '2025-12-15',
       address: {
         line1: '123 Main Street',
         line2: 'Apt 1A',
@@ -537,8 +537,8 @@ const mockCredentials = [
     value: {
       documentNumber: '123456781',
       issuanceState: 'NY',
-      issuanceDate: '1754049600000',
-      expirationDate: '1765800000000',
+      issuanceDate: '2025-08-01',
+      expirationDate: '2025-12-15',
       address: {
         line1: '123 Main Street',
         line2: 'Apt 1A',
@@ -554,7 +554,7 @@ const mockCredentials = [
     type: 'healthInsurance',
     value: {
       id: 174,
-      memberId: 'AC****02',
+      memberId: '00****00',
       payer: {
         verifiedId: 'V123123',
         name: 'Aviato Health Insurance Of California',

--- a/src/validations/date.schema.ts
+++ b/src/validations/date.schema.ts
@@ -119,13 +119,37 @@ export const refineAge18Plus = (value: string) => {
   return validateAge18Plus(value);
 };
 
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+const MASKED_DATE_REGEX = /^•{4}-\d{2}-\d{2}$/;
+
+// Returns true for a valid YYYY-MM-DD date string (server-formatted credentials).
+const isValidIsoDate = (value: string): boolean =>
+  ISO_DATE_REGEX.test(value) && !isNaN(new Date(value).getTime());
+
+// Returns true for a server-masked birthDate (••••-MM-DD).
+// The server already validated the credential; the year is intentionally hidden.
+const isServerMaskedDate = (value: string): boolean => MASKED_DATE_REGEX.test(value);
+
+const isValidIsoAge18Plus = (value: string): boolean => {
+  const birthDate = new Date(value);
+  const eighteenYearsAgo = new Date();
+  eighteenYearsAgo.setUTCFullYear(eighteenYearsAgo.getUTCFullYear() - 18);
+  return birthDate <= eighteenYearsAgo;
+};
+
 export const dateSchema = zod
   .string()
-  .refine(refineTimestamp, '')
-  .refine(refineMinimumDate1900, '');
+  .refine((v) => isServerMaskedDate(v) || isValidIsoDate(v) || refineTimestamp(v), '')
+  .refine((v) => isServerMaskedDate(v) || isValidIsoDate(v) || refineMinimumDate1900(v), '');
 
 export const birthDateSchema = zod
   .string()
-  .refine(refineTimestamp, '')
-  .refine(refineMinimumDate1900, '')
-  .refine(refineAge18Plus, 'Must be 18 years or older');
+  .refine((v) => isServerMaskedDate(v) || isValidIsoDate(v) || refineTimestamp(v), '')
+  .refine((v) => isServerMaskedDate(v) || isValidIsoDate(v) || refineMinimumDate1900(v), '')
+  .refine(
+    (v) => {
+      if (isServerMaskedDate(v)) return true;
+      return isValidIsoDate(v) ? isValidIsoAge18Plus(v) : refineAge18Plus(v);
+    },
+    'Must be 18 years or older',
+  );

--- a/src/validations/date.schema.ts
+++ b/src/validations/date.schema.ts
@@ -158,10 +158,7 @@ export const birthDateSchema = zod
   )
   .refine(
     (v) =>
-      isServerMaskedDate(v) ||
-      (isValidIsoDate(v)
-        ? Number(v.slice(0, 4)) >= 1900
-        : refineMinimumDate1900(v)),
+      isServerMaskedDate(v) || isValidIsoDate(v) || refineMinimumDate1900(v),
     '',
   )
   .refine((v) => {

--- a/src/validations/date.schema.ts
+++ b/src/validations/date.schema.ts
@@ -158,7 +158,10 @@ export const birthDateSchema = zod
   )
   .refine(
     (v) =>
-      isServerMaskedDate(v) || isValidIsoDate(v) || refineMinimumDate1900(v),
+      isServerMaskedDate(v) ||
+      (isValidIsoDate(v)
+        ? Number(v.slice(0, 4)) >= 1900
+        : refineMinimumDate1900(v)),
     '',
   )
   .refine((v) => {

--- a/src/validations/date.schema.ts
+++ b/src/validations/date.schema.ts
@@ -128,7 +128,8 @@ const isValidIsoDate = (value: string): boolean =>
 
 // Returns true for a server-masked birthDate (••••-MM-DD).
 // The server already validated the credential; the year is intentionally hidden.
-const isServerMaskedDate = (value: string): boolean => MASKED_DATE_REGEX.test(value);
+const isServerMaskedDate = (value: string): boolean =>
+  MASKED_DATE_REGEX.test(value);
 
 const isValidIsoAge18Plus = (value: string): boolean => {
   const birthDate = new Date(value);
@@ -139,17 +140,28 @@ const isValidIsoAge18Plus = (value: string): boolean => {
 
 export const dateSchema = zod
   .string()
-  .refine((v) => isServerMaskedDate(v) || isValidIsoDate(v) || refineTimestamp(v), '')
-  .refine((v) => isServerMaskedDate(v) || isValidIsoDate(v) || refineMinimumDate1900(v), '');
+  .refine(
+    (v) => isServerMaskedDate(v) || isValidIsoDate(v) || refineTimestamp(v),
+    '',
+  )
+  .refine(
+    (v) =>
+      isServerMaskedDate(v) || isValidIsoDate(v) || refineMinimumDate1900(v),
+    '',
+  );
 
 export const birthDateSchema = zod
   .string()
-  .refine((v) => isServerMaskedDate(v) || isValidIsoDate(v) || refineTimestamp(v), '')
-  .refine((v) => isServerMaskedDate(v) || isValidIsoDate(v) || refineMinimumDate1900(v), '')
   .refine(
-    (v) => {
-      if (isServerMaskedDate(v)) return true;
-      return isValidIsoDate(v) ? isValidIsoAge18Plus(v) : refineAge18Plus(v);
-    },
-    'Must be 18 years or older',
-  );
+    (v) => isServerMaskedDate(v) || isValidIsoDate(v) || refineTimestamp(v),
+    '',
+  )
+  .refine(
+    (v) =>
+      isServerMaskedDate(v) || isValidIsoDate(v) || refineMinimumDate1900(v),
+    '',
+  )
+  .refine((v) => {
+    if (isServerMaskedDate(v)) return true;
+    return isValidIsoDate(v) ? isValidIsoAge18Plus(v) : refineAge18Plus(v);
+  }, 'Must be 18 years or older');

--- a/tests/components/form/NewOneClickForm/core/form/formField/fields/birthDate.test.ts
+++ b/tests/components/form/NewOneClickForm/core/form/formField/fields/birthDate.test.ts
@@ -247,6 +247,11 @@ describe('birthDate', () => {
         field.value = '1990-13-45';
         expect(field.isValid).toBe(false);
       });
+
+      test('ISO date before 1900 is rejected', () => {
+        field.value = '1899-12-31';
+        expect(field.isValid).toBe(false);
+      });
     });
 
     describe('server-masked date (••••-MM-DD) — IDI partial mask', () => {

--- a/tests/components/form/NewOneClickForm/core/form/formField/fields/birthDate.test.ts
+++ b/tests/components/form/NewOneClickForm/core/form/formField/fields/birthDate.test.ts
@@ -209,5 +209,56 @@ describe('birthDate', () => {
         expect(field.isValid).toBe(true);
       });
     });
+
+    describe('ISO date (YYYY-MM-DD) — new server format', () => {
+      test('valid ISO date for an adult is accepted', () => {
+        field.value = '1990-01-15';
+        expect(field.isValid).toBe(true);
+      });
+
+      test('ISO date for exactly 18 years old is accepted', () => {
+        const now = new Date();
+        const year = now.getUTCFullYear() - 18;
+        const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+        const day = String(now.getUTCDate()).padStart(2, '0');
+        field.value = `${year}-${month}-${day}`;
+        expect(field.isValid).toBe(true);
+      });
+
+      test('ISO date for under-18 person is rejected', () => {
+        const now = new Date();
+        const year = now.getUTCFullYear() - 17;
+        const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+        const day = String(now.getUTCDate()).padStart(2, '0');
+        field.value = `${year}-${month}-${day}`;
+        expect(field.isValid).toBe(false);
+      });
+
+      test('ISO date for 100-year-old adult is accepted', () => {
+        const now = new Date();
+        const year = now.getUTCFullYear() - 100;
+        const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+        const day = String(now.getUTCDate()).padStart(2, '0');
+        field.value = `${year}-${month}-${day}`;
+        expect(field.isValid).toBe(true);
+      });
+
+      test('invalid ISO date string is rejected', () => {
+        field.value = '1990-13-45';
+        expect(field.isValid).toBe(false);
+      });
+    });
+
+    describe('server-masked date (••••-MM-DD) — IDI partial mask', () => {
+      test('masked date is always accepted (server already validated)', () => {
+        field.value = '••••-01-15';
+        expect(field.isValid).toBe(true);
+      });
+
+      test('masked date with different month/day is accepted', () => {
+        field.value = '••••-12-31';
+        expect(field.isValid).toBe(true);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
Adds support for the new ISO `YYYY-MM-DD` server credential date format and server-masked birthDates (`••••-MM-DD`) across date validation, formatting, and the date input field, while preserving backward compatibility with legacy Unix-ms timestamps.

## Changes
- **`date.schema.ts`**: `dateSchema` and `birthDateSchema` now accept ISO `YYYY-MM-DD` dates and server-masked `••••-MM-DD` values in addition to legacy timestamps. Added `isValidIsoDate`, `isServerMaskedDate`, and `isValidIsoAge18Plus` helpers; masked dates bypass validation since the server already validated them.
- **`date.format.ts`**: `dateFormat` now handles masked years (`••••-MM-DD → MM/DD/••••`) and ISO strings (`YYYY-MM-DD → MM/DD/YYYY`), falling back to the legacy Unix-ms timestamp formatting.
- **`date.field.tsx`**: Initializes the input from masked, ISO, or legacy timestamp values. On change, preserves the original credential's format (Unix-ms only when it originally used a timestamp, otherwise writes ISO `YYYY-MM-DD`). Server-masked fields reset to empty on edit so the fake placeholder year is never saved, and force `redactYear` on.
- **`CredentialForm.stories.tsx`**: Updated mock credential dates from Unix-ms timestamps to ISO `YYYY-MM-DD`.
- **`birthDate.test.ts`**: Added tests covering ISO dates (adult, exactly 18, under-18, 100-year-old, invalid string) and server-masked dates.

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
