### PR TITLE
fix/data provider metrics ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2006,9 +2006,9 @@
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7274,9 +7274,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -7287,7 +7287,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -12646,10 +12647,11 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/src/components/chart/ConversionOverTimeChart/index.tsx
+++ b/src/components/chart/ConversionOverTimeChart/index.tsx
@@ -47,6 +47,19 @@ export interface ConversionOverTimeChartView {
   stackMode?: 'stack' | 'none';
 }
 
+/**
+ * Auxiliary boolean toggle rendered to the left of the built-in
+ * Numbers / Percentages group. Consumer owns the selected state so the toggle
+ * can drive consumer-side data or rendering decisions.
+ */
+export interface ConversionOverTimeChartToggle {
+  id: string;
+  label: string;
+  selected: boolean;
+  onChange: (selected: boolean) => void;
+  ariaLabel?: string;
+}
+
 function mapBrandIntervalData({
   brands,
   data,
@@ -131,6 +144,11 @@ export interface ConversionOverTimeChartProps {
   views?: ConversionOverTimeChartView[];
   /** Key of the initially selected view. Defaults to the first view. */
   defaultViewKey?: string;
+  /**
+   * Optional auxiliary toggles rendered left of the Numbers / Percentages
+   * group. Each toggle is independent and controlled by the consumer.
+   */
+  extraToggles?: ConversionOverTimeChartToggle[];
 }
 
 export function ConversionOverTimeChart({
@@ -148,6 +166,7 @@ export function ConversionOverTimeChart({
   showLegendUuid = true,
   views,
   defaultViewKey,
+  extraToggles,
 }: Readonly<ConversionOverTimeChartProps>): React.ReactNode {
   const style = useStyle();
   const timezone = filter.timezone ?? DEFAULT_TIMEZONE;
@@ -261,7 +280,22 @@ export function ConversionOverTimeChart({
           height: style.regularChartWrapper.height,
         }}
       >
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+          {extraToggles?.length ? (
+            <ToggleButtonGroup size='small'>
+              {extraToggles.map((toggle) => (
+                <ToggleButton
+                  key={toggle.id}
+                  value={toggle.id}
+                  selected={toggle.selected}
+                  onChange={() => toggle.onChange(!toggle.selected)}
+                  aria-label={toggle.ariaLabel ?? toggle.label}
+                >
+                  {toggle.label}
+                </ToggleButton>
+              ))}
+            </ToggleButtonGroup>
+          ) : null}
           <ToggleButtonGroup
             value={activeViewKey}
             exclusive

--- a/src/components/chart/ConversionOverTimeChart/index.tsx
+++ b/src/components/chart/ConversionOverTimeChart/index.tsx
@@ -280,22 +280,20 @@ export function ConversionOverTimeChart({
           height: style.regularChartWrapper.height,
         }}
       >
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
-          {extraToggles?.length ? (
-            <ToggleButtonGroup size='small'>
-              {extraToggles.map((toggle) => (
-                <ToggleButton
-                  key={toggle.id}
-                  value={toggle.id}
-                  selected={toggle.selected}
-                  onChange={() => toggle.onChange(!toggle.selected)}
-                  aria-label={toggle.ariaLabel ?? toggle.label}
-                >
-                  {toggle.label}
-                </ToggleButton>
-              ))}
-            </ToggleButtonGroup>
-          ) : null}
+        <Stack direction='row' spacing={1} justifyContent='flex-end'>
+          {extraToggles?.map((toggle) => (
+            <ToggleButton
+              key={toggle.id}
+              value={toggle.id}
+              selected={toggle.selected}
+              onChange={() => toggle.onChange(!toggle.selected)}
+              size='small'
+              aria-label={toggle.ariaLabel ?? toggle.label}
+              aria-pressed={toggle.selected}
+            >
+              {toggle.label}
+            </ToggleButton>
+          ))}
           <ToggleButtonGroup
             value={activeViewKey}
             exclusive
@@ -310,7 +308,7 @@ export function ConversionOverTimeChart({
               </ToggleButton>
             ))}
           </ToggleButtonGroup>
-        </Box>
+        </Stack>
         {isLoadingEmpty ? (
           <LoadingChartSection />
         ) : isEmpty ? (

--- a/src/stories/components/chart/OneClickSignupConversionChart.stories.tsx
+++ b/src/stories/components/chart/OneClickSignupConversionChart.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Box, Stack } from '@mui/material';
 
@@ -209,5 +210,65 @@ export const WithLegendNoUuid: Story = {
     filter: { timezone: 'UTC' },
     legendBrand: sampleLegendBrand,
     showLegendUuid: false,
+  },
+};
+
+// Alternate dataset + series config used to demonstrate that `extraToggles`
+// can drive a real swap of what the chart renders. Same date range as
+// `mockRawData` so the x-axis stays comparable; different keys/values so the
+// visual change is obvious when the toggle flips on.
+const variantASeriesConfig = [
+  { key: 'Series X', dataKey: 'seriesX', color: '#7c3aed' },
+  { key: 'Series Y', dataKey: 'seriesY', color: '#f97316' },
+];
+
+const variantAData = [
+  {
+    brandUuid: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    brandName: 'Brand',
+    interval: [
+      { date: '2026-01-10T12:00:00Z', seriesX: 40, seriesY: 32 },
+      { date: '2026-01-11T12:00:00Z', seriesX: 55, seriesY: 30 },
+      { date: '2026-01-12T12:00:00Z', seriesX: 70, seriesY: 28 },
+      { date: '2026-01-13T12:00:00Z', seriesX: 95, seriesY: 26 },
+      { date: '2026-01-14T12:00:00Z', seriesX: 130, seriesY: 23 },
+      { date: '2026-01-15T12:00:00Z', seriesX: 165, seriesY: 20 },
+      { date: '2026-01-16T12:00:00Z', seriesX: 195, seriesY: 145 },
+      { date: '2026-01-17T12:00:00Z', seriesX: 215, seriesY: 155 },
+      { date: '2026-01-18T12:00:00Z', seriesX: 240, seriesY: 145 },
+      { date: '2026-01-19T12:00:00Z', seriesX: 270, seriesY: 130 },
+      { date: '2026-01-20T12:00:00Z', seriesX: 310, seriesY: 115 },
+      { date: '2026-01-21T12:00:00Z', seriesX: 345, seriesY: 100 },
+      { date: '2026-01-22T12:00:00Z', seriesX: 380, seriesY: 185 },
+      { date: '2026-01-23T12:00:00Z', seriesX: 410, seriesY: 165 },
+    ],
+  },
+];
+
+export const WithExtraToggle: Story = {
+  args: {
+    stackMode: 'none',
+    isLoading: false,
+    isSuccess: true,
+    isFetching: false,
+    filter: { timezone: 'UTC' },
+  },
+  render: (args) => {
+    const [variantA, setVariantA] = useState(false);
+    return (
+      <ConversionOverTimeChart
+        {...args}
+        chartData={variantA ? variantAData : mockRawData}
+        seriesConfig={variantA ? variantASeriesConfig : seriesConfig}
+        extraToggles={[
+          {
+            id: 'variant-a',
+            label: 'Variant A',
+            selected: variantA,
+            onChange: setVariantA,
+          },
+        ]}
+      />
+    );
   },
 };

--- a/tests/components/chart/ConversionOverTimeChart.test.tsx
+++ b/tests/components/chart/ConversionOverTimeChart.test.tsx
@@ -1,0 +1,186 @@
+import { useState } from 'react';
+import { afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { createTheme, ThemeProvider } from '@mui/material';
+
+// Recharts' ResponsiveContainer uses ResizeObserver, which jsdom doesn't provide.
+beforeAll(() => {
+  class MockResizeObserver {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  (
+    globalThis as unknown as { ResizeObserver: typeof MockResizeObserver }
+  ).ResizeObserver = MockResizeObserver;
+});
+
+import { ConversionOverTimeChart } from '../../../src/components/chart/ConversionOverTimeChart';
+
+const testTheme = createTheme({
+  palette: {
+    neutral: { main: '#999999' },
+    neutralContrast: { main: '#cccccc' },
+    warningContrast: { main: '#ff9800' },
+    infoContrast: { main: '#2196f3' },
+    dangerContrast: { main: '#f44336' },
+  },
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderChart(
+  props: Record<string, unknown> = {},
+): ReturnType<typeof render> {
+  const defaultProps = {
+    chartData: [
+      {
+        brandUuid: 'b1',
+        brandName: 'Brand 1',
+        interval: [
+          { date: '2026-01-10T12:00:00Z', a: 10, b: 5 },
+          { date: '2026-01-11T12:00:00Z', a: 12, b: 7 },
+        ],
+      },
+    ],
+    seriesConfig: [
+      { key: 'A', dataKey: 'a', color: '#111' },
+      { key: 'B', dataKey: 'b', color: '#222' },
+    ],
+    isLoading: false,
+    isSuccess: true,
+    isFetching: false,
+    filter: { timezone: 'UTC' },
+  };
+  return render(
+    <ThemeProvider theme={testTheme}>
+      <ConversionOverTimeChart {...defaultProps} {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe('ConversionOverTimeChart — extraToggles', () => {
+  test('renders no extra toggles when prop is undefined', () => {
+    renderChart();
+    expect(screen.queryByRole('button', { name: /variant a/i })).toBeNull();
+  });
+
+  test('renders no extra toggles when prop is an empty array', () => {
+    renderChart({ extraToggles: [] });
+    expect(screen.queryByRole('button', { name: /variant a/i })).toBeNull();
+  });
+
+  test('renders one toggle button per entry', () => {
+    renderChart({
+      extraToggles: [
+        { id: 'a', label: 'Variant A', selected: false, onChange: () => {} },
+        { id: 'b', label: 'Variant B', selected: true, onChange: () => {} },
+      ],
+    });
+    expect(screen.getByRole('button', { name: /variant a/i })).not.toBeNull();
+    expect(screen.getByRole('button', { name: /variant b/i })).not.toBeNull();
+  });
+
+  test('reflects the `selected` prop on each toggle via aria-pressed', () => {
+    renderChart({
+      extraToggles: [
+        { id: 'a', label: 'Variant A', selected: false, onChange: () => {} },
+        { id: 'b', label: 'Variant B', selected: true, onChange: () => {} },
+      ],
+    });
+    expect(
+      screen
+        .getByRole('button', { name: /variant a/i })
+        .getAttribute('aria-pressed'),
+    ).toBe('false');
+    expect(
+      screen
+        .getByRole('button', { name: /variant b/i })
+        .getAttribute('aria-pressed'),
+    ).toBe('true');
+  });
+
+  test('clicking a toggle invokes onChange with the flipped selected value', () => {
+    const calls: boolean[] = [];
+    renderChart({
+      extraToggles: [
+        {
+          id: 'a',
+          label: 'Variant A',
+          selected: false,
+          onChange: (value: boolean) => calls.push(value),
+        },
+      ],
+    });
+    fireEvent.click(screen.getByRole('button', { name: /variant a/i }));
+    expect(calls).toEqual([true]);
+  });
+
+  test('uses ariaLabel when supplied, falling back to label otherwise', () => {
+    renderChart({
+      extraToggles: [
+        {
+          id: 'a',
+          label: 'Variant A',
+          ariaLabel: 'Show Variant A series',
+          selected: false,
+          onChange: () => {},
+        },
+        { id: 'b', label: 'Variant B', selected: false, onChange: () => {} },
+      ],
+    });
+    expect(
+      screen.getByRole('button', { name: /show variant a series/i }),
+    ).not.toBeNull();
+    expect(screen.getByRole('button', { name: /variant b/i })).not.toBeNull();
+  });
+
+  test('Numbers / Percentages toggle group still renders alongside extra toggles', () => {
+    renderChart({
+      extraToggles: [
+        { id: 'a', label: 'Variant A', selected: false, onChange: () => {} },
+      ],
+    });
+    expect(screen.getByRole('button', { name: /numbers/i })).not.toBeNull();
+    expect(screen.getByRole('button', { name: /percentages/i })).not.toBeNull();
+  });
+
+  test('Numbers / Percentages still drives view switching when extra toggles are present', () => {
+    function Harness(): ReturnType<typeof ConversionOverTimeChart> {
+      const [extraOn, setExtraOn] = useState(false);
+      return (
+        <ThemeProvider theme={testTheme}>
+          <ConversionOverTimeChart
+            chartData={[
+              {
+                brandUuid: 'b1',
+                brandName: 'Brand 1',
+                interval: [{ date: '2026-01-10T12:00:00Z', a: 10 }],
+              },
+            ]}
+            seriesConfig={[{ key: 'A', dataKey: 'a', color: '#111' }]}
+            isLoading={false}
+            isSuccess={true}
+            isFetching={false}
+            filter={{ timezone: 'UTC' }}
+            extraToggles={[
+              {
+                id: 'x',
+                label: 'Variant A',
+                selected: extraOn,
+                onChange: setExtraOn,
+              },
+            ]}
+          />
+        </ThemeProvider>
+      );
+    }
+    render(<Harness />);
+    const percentages = screen.getByRole('button', { name: /percentages/i });
+    fireEvent.click(percentages);
+    // After clicking Percentages, that view becomes selected (aria-pressed=true).
+    expect(percentages.getAttribute('aria-pressed')).toBe('true');
+  });
+});


### PR DESCRIPTION
## Summary
Adds a generic toggle to the OverTimeChart, used to compose with existing "Numbers" | "Percentages" group.

## Changes
- feat: add auxiliary toggle interface and support for extra toggles in ConversionOverTimeChart
- feat: refactor toggle button layout in ConversionOverTimeChart for improved UI
- feat: add extra toggle story and tests for ConversionOverTimeChart

## Testing
- `npm run test` - 254 passing
- `npm run storybook`
  - navigate to chart > ConversionOverTimeChart > Signup Conversion > With Extra Toggle
  - Select to change the data shown, both "Numbers" and "Percentages" work with toggle on and off

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
