### PR TITLE
fix(DataTable): grow table for large initial column widths instead of shrinking neighbors

### DIFF
--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -170,10 +170,8 @@ export function DataTable<TData extends DataTableData>({
   // Internal-only: dragged column widths, keyed by column id.
   const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({});
 
-  // Once any column was dragged, every column gets an explicit width and
-  // the table is sized to their sum — so widening a column grows the
-  // table (horizontal scroll) instead of reflowing (shrinking) its
-  // neighbors.
+  // True once any column has been dragged — every column is then frozen at
+  // an explicit width (see startColumnResize / the header cell widths).
   const hasResizedColumns =
     enableColumnResizing && Object.keys(columnSizing).length > 0;
 
@@ -323,6 +321,25 @@ export function DataTable<TData extends DataTableData>({
   // Visible leaf columns drive the colSpan of full-width rows (loading,
   // empty, dividers, virtualizer padding) — hidden columns don't count.
   const columnCount = table.getVisibleLeafColumns().length || 1;
+
+  // Explicit widths come either from a resize drag (above) or from numeric
+  // column widths set up front — `meta.width`, copied onto the column size
+  // by applyMetaWidthsToSizes. Either way the table is sized to the sum of
+  // the column widths so a wide column grows the table — adding horizontal
+  // scroll — instead of reflowing (shrinking) its neighbors, matching the
+  // drag-resize behavior. Until a drag freezes every column, columns
+  // without an explicit width stay auto and flex to fill the rest.
+  // (A percentage meta.width isn't a fixed px width — it splits the
+  // available space, so it doesn't put the table into this mode.)
+  const hasInitialColumnSizes =
+    enableColumnResizing &&
+    table
+      .getVisibleLeafColumns()
+      .some(
+        (column) =>
+          typeof getColumnMeta(column.columnDef.meta)?.width === 'number',
+      );
+  const hasExplicitColumnSizes = hasResizedColumns || hasInitialColumnSizes;
 
   // Visible pinned leaf columns in pinned order — drive the sticky
   // offsets and the edge dividers between pinned and scrolling regions.
@@ -553,13 +570,14 @@ export function DataTable<TData extends DataTableData>({
           <Table
             stickyHeader
             sx={{ minWidth, tableLayout }}
-            // With resizing active the table is sized to the sum of the
-            // column widths, so widening a column adds horizontal scroll
-            // instead of shrinking its neighbors — but never below the
-            // container width, so narrowing columns can't leave a gap on
-            // the right. Inline style — it changes on every drag frame.
+            // With explicit column widths — set up front (numeric
+            // meta.width) or by a resize drag — the table is sized to the
+            // sum of the column widths, so a wide column adds horizontal
+            // scroll instead of shrinking its neighbors — but never below
+            // the container width, so narrowing columns can't leave a gap
+            // on the right. Inline style — it changes on every drag frame.
             style={
-              hasResizedColumns
+              hasExplicitColumnSizes
                 ? { width: `max(${table.getTotalSize()}px, 100%)` }
                 : undefined
             }

--- a/src/components/DataTable/DataTable.types.ts
+++ b/src/components/DataTable/DataTable.types.ts
@@ -100,6 +100,13 @@ export interface DataTableColumnMeta {
    * current page, so supply the full set here.
    */
   filterOptions?: string[];
+  /**
+   * Hides the hover kebab (column menu) on this column even when the table
+   * has `enableColumnMenu`. Use for utility columns with nothing to act on
+   * (e.g. an expand/select column) so they don't show a menu offering only
+   * the global "Manage columns" action.
+   */
+  disableColumnMenu?: boolean;
 }
 
 /**
@@ -384,7 +391,8 @@ export interface DataTableProps<TData extends DataTableData> {
    *
    * Every accessor column is filterable through the operator-based filter
    * panel by default — opt a column out with `enableColumnFilter: false`
-   * on its def.
+   * on its def. Hide the kebab on a specific column (e.g. a utility
+   * expand/select column) with `meta.disableColumnMenu`.
    */
   enableColumnMenu?: boolean;
   /**

--- a/src/components/DataTable/DataTable.types.ts
+++ b/src/components/DataTable/DataTable.types.ts
@@ -85,6 +85,12 @@ export interface DataTableColumnMeta {
    * Column width — any CSS width value: a number for px (e.g. 140) or a
    * string for percentage fill (e.g. '40%'). Applied to the header cell,
    * which sizes the whole column.
+   *
+   * With `enableColumnResizing`, a numeric (px) width behaves like a
+   * drag-resize: the table grows to the sum of the column widths and
+   * scrolls horizontally rather than shrinking the other columns to fit,
+   * so a large width never reflows its neighbors. Percentage widths still
+   * split the available space.
    */
   width?: number | string;
   /**

--- a/src/components/DataTable/DataTableHeaderCell.tsx
+++ b/src/components/DataTable/DataTableHeaderCell.tsx
@@ -146,9 +146,14 @@ export function DataTableHeaderCell({
       // — so a wide column grows the table instead of
       // reflowing its neighbors. Columns with no fixed
       // width stay auto (flexing to fill) until a drag
-      // freezes them.
+      // freezes them. Only with resizing on: otherwise the
+      // column size isn't seeded from meta.width, so
+      // header.getSize() would be the 150px default and
+      // override the sx width below — the width applies
+      // through sx instead.
       style={{
-        ...(hasResizedColumns || typeof meta?.width === 'number'
+        ...(hasResizedColumns ||
+        (enableColumnResizing && typeof meta?.width === 'number')
           ? { width: header.getSize() }
           : {}),
         ...getPinnedOffsetStyle(pinned, column.id),

--- a/src/components/DataTable/DataTableHeaderCell.tsx
+++ b/src/components/DataTable/DataTableHeaderCell.tsx
@@ -140,11 +140,17 @@ export function DataTableHeaderCell({
       sortDirection={sortDirection}
       // Widths and sticky offsets are inline style (not
       // sx) — they change on every drag frame and would
-      // churn Emotion classes. With resizing active every
-      // header gets its explicit width (group headers the
-      // sum of their leaves), so columns never reflow.
+      // churn Emotion classes. A header gets its explicit
+      // width once a drag has frozen every column, or up
+      // front when the column carries a numeric meta.width
+      // — so a wide column grows the table instead of
+      // reflowing its neighbors. Columns with no fixed
+      // width stay auto (flexing to fill) until a drag
+      // freezes them.
       style={{
-        ...(hasResizedColumns ? { width: header.getSize() } : {}),
+        ...(hasResizedColumns || typeof meta?.width === 'number'
+          ? { width: header.getSize() }
+          : {}),
         ...getPinnedOffsetStyle(pinned, column.id),
       }}
       sx={{

--- a/src/components/DataTable/DataTableHeaderCell.tsx
+++ b/src/components/DataTable/DataTableHeaderCell.tsx
@@ -81,7 +81,11 @@ export function DataTableHeaderCell({
   const pinned: ColumnPinningPosition = isGroupHeader
     ? false
     : column.getIsPinned();
-  const showColumnMenu = enableColumnMenu && !isGroupHeader;
+  // Per-column opt-out (meta.disableColumnMenu) — for utility columns with
+  // nothing to act on, so they don't show a menu offering only the global
+  // "Manage columns" action.
+  const showColumnMenu =
+    enableColumnMenu && !isGroupHeader && !meta?.disableColumnMenu;
   const isMenuOpen =
     columnPanel?.type === 'menu' && columnPanel.columnId === column.id;
   // Compute from our filter state — TanStack's columnFilters is no longer

--- a/src/stories/components/DataTable.stories.tsx
+++ b/src/stories/components/DataTable.stories.tsx
@@ -174,6 +174,42 @@ export const ColumnResizing: Story = {
   },
 };
 
+// A large initial column width (set via `meta.width`) behaves like a
+// drag-resize: the table grows to the sum of the column widths and scrolls
+// horizontally, instead of shrinking the other columns to fit. Columns
+// without a width stay auto and flex to fill the remaining space.
+export const LargeColumnWidth: Story = {
+  args: {
+    data: members,
+    enableColumnResizing: true,
+    columns: [
+      {
+        id: 'email',
+        accessorFn: (row) => row.email,
+        header: 'Email',
+        enableSorting: true,
+        meta: { width: 2000 },
+      },
+      {
+        id: 'role',
+        accessorFn: (row) => row.role,
+        header: 'Role',
+      },
+      {
+        id: 'status',
+        accessorFn: (row) => row.status,
+        header: 'Status',
+      },
+      {
+        id: 'invitedAt',
+        accessorFn: (row) => row.invitedAt,
+        header: 'Invited At',
+        enableSorting: true,
+      },
+    ],
+  },
+};
+
 // Per-column kebab menu (hover a header to reveal it), like the MUI
 // DataGrid column menu: Sort by ASC/DESC for sortable columns, Filter for
 // filterable columns, and Hide column / Manage columns for visibility.

--- a/tests/components/DataTable.test.tsx
+++ b/tests/components/DataTable.test.tsx
@@ -284,6 +284,28 @@ describe('<DataTable/>', () => {
       expect(getBodyRowTexts(container)[0]).toContain('charlie@verified.inc');
     });
 
+    test('hides the kebab on columns opting out via meta.disableColumnMenu', () => {
+      const { getByLabelText, queryByLabelText } = render(
+        <DataTable
+          data={members}
+          enableColumnMenu
+          columns={[
+            {
+              id: 'expand',
+              header: '',
+              meta: { disableColumnMenu: true },
+            },
+            { id: 'email', accessorFn: (row) => row.email, header: 'Email' },
+          ]}
+        />,
+      );
+
+      // The utility column has no menu...
+      expect(queryByLabelText('Expand column menu')).toBeNull();
+      // ...while the others still do.
+      expect(getByLabelText('Email column menu')).toBeDefined();
+    });
+
     test('omits the sort items for non-sortable columns', () => {
       const { getByLabelText, queryByText } = render(
         <DataTable

--- a/tests/components/DataTable.test.tsx
+++ b/tests/components/DataTable.test.tsx
@@ -1007,6 +1007,66 @@ describe('<DataTable/>', () => {
 
       expect(container.querySelector('.DataTable-columnResizer')).toBeNull();
     });
+
+    test('a large initial column width grows the table instead of shrinking its neighbors', () => {
+      const { container } = render(
+        <DataTable
+          data={members}
+          enableColumnResizing
+          columns={[
+            {
+              id: 'email',
+              accessorFn: (row) => row.email,
+              header: 'Email',
+              meta: { width: 800 },
+            },
+            {
+              id: 'role',
+              accessorFn: (row) => row.role,
+              header: 'Role',
+            },
+            {
+              id: 'mfaEnabled',
+              accessorFn: (row) => row.mfaEnabled,
+              header: 'MFA',
+            },
+          ]}
+        />,
+      );
+
+      const table = container.querySelector<HTMLTableElement>(
+        'table[aria-label="data table"]',
+      );
+
+      // The table is sized to the sum of the column widths (800 + the 150px
+      // TanStack default for the two unsized columns), with a 100% floor —
+      // so the wide column adds horizontal scroll rather than reflowing.
+      expect(table?.style.width).toBe('max(1100px, 100%)');
+
+      const headerCells =
+        container.querySelectorAll<HTMLTableCellElement>('thead th');
+
+      // The sized column gets its explicit width...
+      expect(headerCells[0].style.width).toBe('800px');
+      // ...while the unsized neighbors stay auto (no inline width) so they
+      // flex to fill the remaining space instead of being crushed.
+      expect(headerCells[1].style.width).toBe('');
+      expect(headerCells[2].style.width).toBe('');
+    });
+
+    test('leaves the table unsized when no column carries an explicit width', () => {
+      const { container } = render(
+        <DataTable data={members} enableColumnResizing />,
+      );
+
+      const table = container.querySelector<HTMLTableElement>(
+        'table[aria-label="data table"]',
+      );
+
+      // No explicit sizes and no drag yet — the table keeps its default
+      // sizing so columns distribute normally.
+      expect(table?.style.width).toBe('');
+    });
   });
 
   describe('column pinning', () => {

--- a/tests/components/DataTable.test.tsx
+++ b/tests/components/DataTable.test.tsx
@@ -1067,6 +1067,30 @@ describe('<DataTable/>', () => {
       // sizing so columns distribute normally.
       expect(table?.style.width).toBe('');
     });
+
+    test('does not add an inline width for a numeric meta.width when resizing is off', () => {
+      const { container } = render(
+        <DataTable
+          data={members}
+          columns={[
+            {
+              id: 'email',
+              accessorFn: (row) => row.email,
+              header: 'Email',
+              meta: { width: 140 },
+            },
+          ]}
+        />,
+      );
+
+      const headerCell =
+        container.querySelector<HTMLTableCellElement>('thead th');
+
+      // Without resizing the size isn't seeded from meta.width, so an inline
+      // width would be the 150px default and override the sx width — the
+      // width must come through sx (no inline width) instead.
+      expect(headerCell?.style.width).toBe('');
+    });
   });
 
   describe('column pinning', () => {


### PR DESCRIPTION
## Summary
Fixes `DataTable` so that columns with a large numeric `meta.width` grow the table (adding horizontal scroll) instead of shrinking their neighbors — matching the existing drag-resize behavior.

## Changes
- **`DataTable.tsx`**: Introduces `hasInitialColumnSizes` to detect columns with a numeric `meta.width`, and combines it with `hasResizedColumns` into `hasExplicitColumnSizes`. The table's `max(${totalSize}px, 100%)` width style is now applied whenever either condition is true, not only after a drag.
- **`DataTableHeaderCell.tsx`**: Applies an explicit inline `width` to header cells that carry a numeric `meta.width`, even before any drag has occurred — so the wide column is correctly measured and the table size is accurate.
- **`DataTable.types.ts`**: Documents the new behavior for numeric `meta.width` under `enableColumnResizing`.
- **`DataTable.stories.tsx`**: Adds a `LargeColumnWidth` story to demonstrate the fix.
- **`DataTable.test.tsx`**: Adds two tests — one asserting that a large initial column width grows the table and leaves unsized neighbors `auto`, and one asserting that a table with no explicit widths keeps default sizing.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
