### PR TITLE
feat: add usePersistedState hook and corresponding stories

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -23,3 +23,4 @@ export * from './text-to-signup';
 export * from './useNetworkType';
 export * from './metrics';
 export * from './useBidirectionalScroll';
+export * from './usePersistedState';

--- a/src/hooks/usePersistedState.ts
+++ b/src/hooks/usePersistedState.ts
@@ -37,7 +37,10 @@ export function usePersistedState<T>(
     (action: SetStateAction<T | null>) =>
       setState((prev) => ({
         ...prev,
-        value: typeof action === 'function' ? action(prev.value) : action,
+        value:
+          typeof action === 'function'
+            ? (action as (prev: T | null) => T | null)(prev.value)
+            : action,
       })),
     [],
   );

--- a/src/hooks/usePersistedState.ts
+++ b/src/hooks/usePersistedState.ts
@@ -1,55 +1,73 @@
 'use client';
 
-import { type Dispatch, type SetStateAction, useEffect, useState } from 'react';
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 
 export interface Persistor<T> {
   get: () => T | null | Promise<T | null>;
   set: (value: T) => void | Promise<void>;
 }
 
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return typeof (value as { then?: unknown })?.then === 'function';
+}
+
 export function usePersistedState<T>(
   initialState: T,
   persistor: Persistor<T>,
 ): [T | null, Dispatch<SetStateAction<T | null>>, boolean] {
-  const [value, setValue] = useState<T | null>(() => {
-    try {
-      const result = persistor.get();
-      if (result instanceof Promise) return null;
-      return result ?? initialState;
-    } catch {
-      return null;
-    }
-  });
+  const [state, setState] = useState<{ value: T | null; ready: boolean }>(
+    () => {
+      try {
+        const result = persistor.get();
+        if (isThenable(result)) return { value: null, ready: false };
+        return { value: (result as T | null) ?? initialState, ready: true };
+      } catch {
+        return { value: null, ready: false };
+      }
+    },
+  );
 
-  const [ready, setReady] = useState(value !== null);
+  const setValue: Dispatch<SetStateAction<T | null>> = useCallback(
+    (action: SetStateAction<T | null>) =>
+      setState((prev) => ({
+        ...prev,
+        value: typeof action === 'function' ? action(prev.value) : action,
+      })),
+    [],
+  );
 
   useEffect(() => {
-    if (!ready) {
+    if (!state.ready) {
       const resolve = async () => {
         try {
           const persisted = await persistor.get();
-          setValue(persisted !== null ? persisted : initialState);
+          setState({ value: persisted ?? initialState, ready: true });
         } catch {
-          setValue(initialState);
+          setState({ value: initialState, ready: true });
         }
-        setReady(true);
       };
       resolve();
     }
   }, []);
 
   useEffect(() => {
-    if (ready && value !== null) {
+    if (state.ready && state.value !== null) {
       const persist = async () => {
         try {
-          await persistor.set(value);
+          await persistor.set(state.value as T);
         } catch {
           // persistor unavailable, skip
         }
       };
       persist();
     }
-  }, [value, ready]);
+  }, [state.value, state.ready]);
 
-  return [value, setValue, ready];
+  return [state.value, setValue, state.ready];
 }

--- a/src/hooks/usePersistedState.ts
+++ b/src/hooks/usePersistedState.ts
@@ -87,7 +87,7 @@ export function usePersistedState<T>(
       };
       persist();
     }
-  }, [state.value, state.ready]);
+  }, [persistor, state.value, state.ready]);
 
   return [state.value, setValue, state.ready];
 }

--- a/src/hooks/usePersistedState.ts
+++ b/src/hooks/usePersistedState.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { type Dispatch, type SetStateAction, useEffect, useState } from 'react';
+
+export interface Persistor<T> {
+  get: () => T | null | Promise<T | null>;
+  set: (value: T) => void | Promise<void>;
+}
+
+export function usePersistedState<T>(
+  initialState: T,
+  persistor: Persistor<T>,
+): [T | null, Dispatch<SetStateAction<T | null>>, boolean] {
+  const [value, setValue] = useState<T | null>(() => {
+    try {
+      const result = persistor.get();
+      if (result instanceof Promise) return null;
+      return result ?? initialState;
+    } catch {
+      return null;
+    }
+  });
+
+  const [ready, setReady] = useState(value !== null);
+
+  useEffect(() => {
+    if (!ready) {
+      const resolve = async () => {
+        try {
+          const persisted = await persistor.get();
+          setValue(persisted !== null ? persisted : initialState);
+        } catch {
+          setValue(initialState);
+        }
+        setReady(true);
+      };
+      resolve();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (ready && value !== null) {
+      const persist = async () => {
+        try {
+          await persistor.set(value);
+        } catch {
+          // persistor unavailable, skip
+        }
+      };
+      persist();
+    }
+  }, [value, ready]);
+
+  return [value, setValue, ready];
+}

--- a/src/hooks/usePersistedState.ts
+++ b/src/hooks/usePersistedState.ts
@@ -46,18 +46,35 @@ export function usePersistedState<T>(
   );
 
   useEffect(() => {
-    if (!state.ready) {
-      const resolve = async () => {
-        try {
-          const persisted = await persistor.get();
-          setState({ value: persisted ?? initialState, ready: true });
-        } catch {
-          setState({ value: initialState, ready: true });
-        }
-      };
-      resolve();
-    }
-  }, []);
+    if (state.ready) return;
+
+    let cancelled = false;
+
+    const resolve = async () => {
+      try {
+        const persisted = await persistor.get();
+        if (cancelled) return;
+
+        setState((prev) => ({
+          value: prev.value !== null ? prev.value : (persisted ?? initialState),
+          ready: true,
+        }));
+      } catch {
+        if (cancelled) return;
+
+        setState((prev) => ({
+          value: prev.value !== null ? prev.value : initialState,
+          ready: true,
+        }));
+      }
+    };
+
+    resolve();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [initialState, persistor, state.ready]);
 
   useEffect(() => {
     if (state.ready && state.value !== null) {

--- a/src/stories/hooks/usePersistedState.stories.tsx
+++ b/src/stories/hooks/usePersistedState.stories.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import { Meta, StoryFn } from '@storybook/react';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
-import { usePersistedState, type Persistor } from '../../hooks/usePersistedState';
+import {
+  usePersistedState,
+  type Persistor,
+} from '../../hooks/usePersistedState';
 
 const meta: Meta = {
   title: 'Hooks/usePersistedState',
@@ -105,7 +108,14 @@ const ObjectExample = () => {
           Persists a structured object. Changes are written to{' '}
           <code>localStorage</code> automatically on every update.
         </p>
-        <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' as const, marginBottom: '0.75rem' }}>
+        <div
+          style={{
+            display: 'flex',
+            gap: '1rem',
+            flexWrap: 'wrap' as const,
+            marginBottom: '0.75rem',
+          }}
+        >
           <label>
             Theme:{' '}
             <select
@@ -181,8 +191,8 @@ const AsyncExample = () => {
       <div style={containerStyle}>
         <p>
           When <code>get</code> returns a <code>Promise</code>, the lazy
-          initializer detects it and returns <code>null</code> immediately.
-          The effect awaits the promise and sets <code>ready</code> once it
+          initializer detects it and returns <code>null</code> immediately. The
+          effect awaits the promise and sets <code>ready</code> once it
           resolves. Reload the story — the value is remembered in the simulated
           store for the session.
         </p>
@@ -227,10 +237,10 @@ const FallbackExample = () => {
     <Section title='Failing persistor (SSR / unavailable storage)'>
       <div style={containerStyle}>
         <p>
-          When the persistor throws (e.g. during SSR), <code>value</code>{' '}
-          starts as <code>null</code> and <code>ready</code> is{' '}
-          <code>false</code>. The effect recovers after mount, setting{' '}
-          <code>value</code> to <code>initialState</code>.
+          When the persistor throws (e.g. during SSR), <code>value</code> starts
+          as <code>null</code> and <code>ready</code> is <code>false</code>. The
+          effect recovers after mount, setting <code>value</code> to{' '}
+          <code>initialState</code>.
         </p>
         <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
           <input

--- a/src/stories/hooks/usePersistedState.stories.tsx
+++ b/src/stories/hooks/usePersistedState.stories.tsx
@@ -1,0 +1,309 @@
+import * as React from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+import { useLocalStorage } from '../../hooks/useLocalStorage';
+import { usePersistedState, type Persistor } from '../../hooks/usePersistedState';
+
+const meta: Meta = {
+  title: 'Hooks/usePersistedState',
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+  },
+};
+
+export default meta;
+
+const Section = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) => (
+  <div style={{ marginBottom: '2rem' }}>
+    <h3 style={{ marginBottom: '1rem' }}>{title}</h3>
+    {children}
+  </div>
+);
+
+const containerStyle = {
+  padding: '1rem',
+  border: '1px solid #ccc',
+  borderRadius: '4px',
+  marginBottom: '1rem',
+};
+
+const valueStyle = {
+  padding: '0.5rem',
+  backgroundColor: '#f5f5f5',
+  borderRadius: '4px',
+  marginTop: '0.5rem',
+  fontFamily: 'monospace' as const,
+};
+
+const badgeStyle = (color: string) => ({
+  display: 'inline-block',
+  padding: '0.2rem 0.5rem',
+  borderRadius: '4px',
+  backgroundColor: color,
+  color: '#fff',
+  fontSize: '0.75rem',
+  marginLeft: '0.5rem',
+});
+
+// --- String example ---
+
+const StringExample = () => {
+  const storage = useLocalStorage('persisted-state-string-demo');
+  const [value, setValue, ready] = usePersistedState('Hello, World!', storage);
+
+  return (
+    <Section title='String value'>
+      <div style={containerStyle}>
+        <p>
+          Persists a string to <code>localStorage</code>. Reload the page — the
+          value survives.
+        </p>
+        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+          <input
+            disabled={!ready}
+            value={value ?? ''}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder='Type something…'
+            style={{ flex: 1, padding: '0.4rem' }}
+          />
+          <button onClick={() => setValue('Hello, World!')}>Reset</button>
+          <span style={badgeStyle(ready ? '#2e7d32' : '#c62828')}>
+            {ready ? 'ready' : 'loading'}
+          </span>
+        </div>
+        <div style={valueStyle}>value: {JSON.stringify(value)}</div>
+      </div>
+    </Section>
+  );
+};
+
+// --- Object example ---
+
+interface UserPrefs {
+  theme: 'light' | 'dark';
+  fontSize: number;
+}
+
+const defaultPrefs: UserPrefs = { theme: 'light', fontSize: 14 };
+
+const ObjectExample = () => {
+  const storage = useLocalStorage('persisted-state-prefs-demo');
+  const [prefs, setPrefs, ready] = usePersistedState<UserPrefs>(
+    defaultPrefs,
+    storage,
+  );
+
+  return (
+    <Section title='Object value (user preferences)'>
+      <div style={containerStyle}>
+        <p>
+          Persists a structured object. Changes are written to{' '}
+          <code>localStorage</code> automatically on every update.
+        </p>
+        <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' as const, marginBottom: '0.75rem' }}>
+          <label>
+            Theme:{' '}
+            <select
+              disabled={!ready}
+              value={prefs?.theme ?? defaultPrefs.theme}
+              onChange={(e) =>
+                setPrefs((p) => ({
+                  ...(p ?? defaultPrefs),
+                  theme: e.target.value as UserPrefs['theme'],
+                }))
+              }
+            >
+              <option value='light'>light</option>
+              <option value='dark'>dark</option>
+            </select>
+          </label>
+          <label>
+            Font size:{' '}
+            <input
+              type='number'
+              disabled={!ready}
+              value={prefs?.fontSize ?? defaultPrefs.fontSize}
+              min={10}
+              max={24}
+              style={{ width: '4rem' }}
+              onChange={(e) =>
+                setPrefs((p) => ({
+                  ...(p ?? defaultPrefs),
+                  fontSize: Number(e.target.value),
+                }))
+              }
+            />
+          </label>
+          <button onClick={() => setPrefs(defaultPrefs)}>Reset</button>
+          <span style={badgeStyle(ready ? '#2e7d32' : '#c62828')}>
+            {ready ? 'ready' : 'loading'}
+          </span>
+        </div>
+        <div style={valueStyle}>{JSON.stringify(prefs, null, 2)}</div>
+      </div>
+    </Section>
+  );
+};
+
+// --- Async persistor (simulates IndexedDB / remote storage) ---
+
+const asyncStore: Record<string, string> = {};
+
+function makeAsyncPersistor(key: string, delayMs = 800): Persistor<string> {
+  return {
+    get: () =>
+      new Promise((resolve) =>
+        setTimeout(() => resolve(asyncStore[key] ?? null), delayMs),
+      ),
+    set: (value) =>
+      new Promise((resolve) =>
+        setTimeout(() => {
+          asyncStore[key] = value;
+          resolve();
+        }, delayMs),
+      ),
+  };
+}
+
+const AsyncExample = () => {
+  const [value, setValue, ready] = usePersistedState(
+    'async default',
+    makeAsyncPersistor('async-demo'),
+  );
+
+  return (
+    <Section title='Async persistor (simulated 800 ms delay)'>
+      <div style={containerStyle}>
+        <p>
+          When <code>get</code> returns a <code>Promise</code>, the lazy
+          initializer detects it and returns <code>null</code> immediately.
+          The effect awaits the promise and sets <code>ready</code> once it
+          resolves. Reload the story — the value is remembered in the simulated
+          store for the session.
+        </p>
+        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+          <input
+            disabled={!ready}
+            value={value ?? ''}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder='Type something…'
+            style={{ flex: 1, padding: '0.4rem' }}
+          />
+          <span style={badgeStyle(ready ? '#2e7d32' : '#c62828')}>
+            {ready ? 'ready' : 'loading…'}
+          </span>
+        </div>
+        <div style={valueStyle}>value: {JSON.stringify(value)}</div>
+      </div>
+    </Section>
+  );
+};
+
+// --- Failing persistor (simulates SSR / unavailable storage) ---
+
+function makeFailingPersistor<T>(): Persistor<T> {
+  return {
+    get: () => {
+      throw new Error('Storage unavailable');
+    },
+    set: () => {
+      throw new Error('Storage unavailable');
+    },
+  };
+}
+
+const FallbackExample = () => {
+  const [value, setValue, ready] = usePersistedState(
+    'fallback default',
+    makeFailingPersistor<string>(),
+  );
+
+  return (
+    <Section title='Failing persistor (SSR / unavailable storage)'>
+      <div style={containerStyle}>
+        <p>
+          When the persistor throws (e.g. during SSR), <code>value</code>{' '}
+          starts as <code>null</code> and <code>ready</code> is{' '}
+          <code>false</code>. The effect recovers after mount, setting{' '}
+          <code>value</code> to <code>initialState</code>.
+        </p>
+        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+          <input
+            disabled={!ready}
+            value={value ?? ''}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder='Type something…'
+            style={{ flex: 1, padding: '0.4rem' }}
+          />
+          <span style={badgeStyle(ready ? '#2e7d32' : '#c62828')}>
+            {ready ? 'ready' : 'loading'}
+          </span>
+        </div>
+        <div style={valueStyle}>value: {JSON.stringify(value)}</div>
+        <p style={{ marginTop: '0.5rem', fontSize: '0.85rem', color: '#666' }}>
+          Note: changes are not persisted here — the persistor always throws.
+        </p>
+      </div>
+    </Section>
+  );
+};
+
+// --- Stories ---
+
+export const Default: StoryFn = () => (
+  <div>
+    <StringExample />
+    <ObjectExample />
+    <AsyncExample />
+    <FallbackExample />
+  </div>
+);
+
+Default.parameters = {
+  docs: {
+    description: {
+      component: `
+A hook that synchronises a state value with any \`Persistor<T>\` (e.g. \`useLocalStorage\`).
+
+### Signature
+
+\`\`\`tsx
+function usePersistedState<T>(
+  initialState: T,
+  persistor: Persistor<T>,
+): [T | null, Dispatch<SetStateAction<T | null>>, boolean]
+\`\`\`
+
+- **\`value\`** — \`null\` until the persistor is read; afterwards \`persistedValue ?? initialState\`.
+- **\`setValue\`** — standard React setter; each call automatically writes back to the persistor.
+- **\`ready\`** — \`true\` once the persisted value has been resolved. Guard renders on this.
+
+### Basic usage
+
+\`\`\`tsx
+const storage = useLocalStorage('my-key');
+const [value, setValue, ready] = usePersistedState('default', storage);
+
+if (!ready) return <Skeleton />;
+return <Input value={value} onChange={e => setValue(e.target.value)} />;
+\`\`\`
+
+### Custom persistor
+
+\`\`\`tsx
+const sessionPersistor: Persistor<string> = {
+  get: () => sessionStorage.getItem('key'),
+  set: (v) => sessionStorage.setItem('key', v),
+};
+
+const [value, setValue, ready] = usePersistedState('default', sessionPersistor);
+\`\`\`
+`,
+    },
+  },
+};


### PR DESCRIPTION
## Summary
Adds a `usePersistedState` hook that synchronizes React state with any pluggable `Persistor<T>` (sync or async), along with comprehensive Storybook stories covering string, object, async, and error-fallback scenarios.

## Changes
- `src/hooks/usePersistedState.ts` — new hook that wraps `useState` with a `Persistor<T>` interface; handles both sync and async `get`/`set`, exposes a `ready` flag to guard renders before the persisted value resolves, and silently recovers from persistor errors (e.g. SSR/unavailable storage)
- `src/hooks/index.ts` — exports the new hook and `Persistor` type
- `src/stories/hooks/usePersistedState.stories.tsx` — four interactive stories: string value via `localStorage`, object (user preferences), async persistor with simulated 800 ms delay, and a failing persistor fallback

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
