### PR TITLE
fix: improve filtering logic in prettyField function

### DIFF
--- a/src/components/CredentialRequestsEditor/utils/prettyField.ts
+++ b/src/components/CredentialRequestsEditor/utils/prettyField.ts
@@ -12,5 +12,5 @@ export const prettyField = (field: string): string =>
       if (word === 'Ssn') return 'SSN';
       return word;
     })
-    .filter((e) => e !== 'Credential')
+    .filter((e) => e.trim() !== '' && e !== 'Credential')
     .join(' ');

--- a/src/components/CredentialRequestsEditor/utils/prettyField.ts
+++ b/src/components/CredentialRequestsEditor/utils/prettyField.ts
@@ -6,11 +6,12 @@ const schemaNamePattern = /([A-Z][a-z0-9]+)/gm;
 export const prettyField = (field: string): string =>
   field
     .split(schemaNamePattern)
+    .map((word) => word.trim())
+    .filter((word) => word !== '' && word !== 'Credential')
     .map((word) => {
       if (word === 'Id') return 'ID';
       if (word === 'Zip') return 'ZIP';
       if (word === 'Ssn') return 'SSN';
       return word;
     })
-    .filter((e) => e.trim() !== '' && e !== 'Credential')
     .join(' ');


### PR DESCRIPTION
## Summary
Fixes the `prettyField` utility in the Credential Requests Editor to drop empty/whitespace-only segments produced when splitting a camel-cased field name, preventing extra spaces in the formatted output.

## Changes
- In `prettyField`, the filter now excludes empty/whitespace-only entries (`e.trim() !== ''`) in addition to the existing `'Credential'` exclusion, so the joined result no longer contains stray spaces.

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
