### PR TITLE
feat: add 1-Click Health Checks Started metric

### DIFF
--- a/src/components/chart/BillableEventsTable/BillableEventsTable.types.ts
+++ b/src/components/chart/BillableEventsTable/BillableEventsTable.types.ts
@@ -94,6 +94,11 @@ export const BILLABLE_PRODUCTS: BillableProductConfig[] = [
         label: 'Autofills Started',
         metricKey: 'oneClickHealthCreated',
       },
+      {
+        key: 'health_checksStarted',
+        label: 'Checks Started',
+        metricKey: 'oneClickHealthCheckStarted',
+      },
     ],
   },
 ];

--- a/tests/components/chart/BillableEventsTable.test.tsx
+++ b/tests/components/chart/BillableEventsTable.test.tsx
@@ -94,6 +94,28 @@ describe('<BillableEventsTable/>', () => {
     expect(getAllByText('Pied Piper').length).toBeGreaterThanOrEqual(2);
   });
 
+  test('renders the 1-Click Health "Checks Started" and "Autofills Started" columns', () => {
+    const data = [
+      makeRow({
+        brandUuid: 'health-uuid',
+        brand: 'Health Co',
+        metrics: { health_autofillsStarted: 7, health_checksStarted: 12 },
+      }),
+    ];
+    const { getByText } = render(
+      <BillableEventsTable
+        data={data}
+        isLoading={false}
+        isFetching={false}
+        visibleProducts={[BillableProduct.ONE_CLICK_HEALTH]}
+      />,
+    );
+    expect(getByText('Autofills Started')).toBeDefined();
+    expect(getByText('Checks Started')).toBeDefined();
+    // The checks column reads the oneClickHealthCheckStarted metric.
+    expect(getByText('12')).toBeDefined();
+  });
+
   test('renders em-dash placeholder when customerName is missing', () => {
     const data = [
       makeRow({


### PR DESCRIPTION
## Summary
Adds mapping to Health checks column in billing table

## Changes
- feat: add "Checks Started" column to BillableEventsTable and corresponding test

## Testing
- `npm run test` - 352 passing

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [x] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
