### PR TITLE
feat: add HealthPayersInput component and related stories for health insurance payer selection

### DIFF
--- a/src/components/form/HealthPayersInput/index.tsx
+++ b/src/components/form/HealthPayersInput/index.tsx
@@ -88,7 +88,7 @@ function useHealthInsuranceProviders(
         limit: PROVIDERS_PAGE_SIZE,
         skip: skipRef.current,
       });
-      const newProviders = (result as HealthPayer[]) ?? [];
+      const newProviders = Array.isArray(result) ? (result as HealthPayer[]) : [];
 
       setAllProviders((prev) => [...prev, ...newProviders]);
       skipRef.current += newProviders.length;

--- a/src/components/form/HealthPayersInput/index.tsx
+++ b/src/components/form/HealthPayersInput/index.tsx
@@ -67,12 +67,13 @@ function useHealthInsuranceProviders(
         signal,
       );
 
-      return Array.isArray(result) ? (result as HealthPayer[]) : [];
-    },
-    onSuccess: (providers) => {
+      const providers = Array.isArray(result) ? (result as HealthPayer[]) : [];
+
       skipRef.current = providers.length;
       setAllProviders(providers);
       setHasMore(providers.length >= PROVIDERS_PAGE_SIZE);
+
+      return providers;
     },
     refetchOnMount: true,
     enabled: !!fetchPayers,

--- a/src/components/form/HealthPayersInput/index.tsx
+++ b/src/components/form/HealthPayersInput/index.tsx
@@ -1,0 +1,268 @@
+import { useCallback, useRef, useState, type ReactNode } from 'react';
+import {
+  Autocomplete,
+  Avatar,
+  Box,
+  Stack,
+  TextField,
+  Typography,
+  type TextFieldProps,
+} from '@mui/material';
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+} from '@tanstack/react-query';
+
+import { useDebounceValue } from '../../../hooks/useDebounceValue';
+
+export type HealthPayer = {
+  verifiedId: string;
+  name: string;
+  logoUrl?: string | null;
+};
+
+export type FetchHealthPayers = (
+  params?: { search?: string; limit?: number; skip?: number },
+  signal?: AbortSignal,
+) => Promise<unknown>;
+
+export interface HealthPayersInputProps {
+  /** Currently selected payer. */
+  value?: HealthPayer | null;
+  /** Called with the selected payer, or null when cleared. */
+  onChange?: (payer: HealthPayer | null) => void;
+  /** Fetches the payer options. Receives `{ search, limit, skip }` for pagination. */
+  fetchPayers?: FetchHealthPayers;
+  disabled?: boolean;
+  label?: ReactNode;
+  helperText?: ReactNode;
+  placeholder?: string;
+  size?: TextFieldProps['size'];
+  /** Optional React Query client. When omitted, an internal one is used. */
+  queryClient?: QueryClient;
+}
+
+const PROVIDERS_PAGE_SIZE = 20;
+
+function useHealthInsuranceProviders(
+  search: string,
+  fetchPayers?: FetchHealthPayers,
+) {
+  const debouncedSearch = useDebounceValue(search, 300);
+  const [allProviders, setAllProviders] = useState<HealthPayer[]>([]);
+  const [hasMore, setHasMore] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const skipRef = useRef(0);
+
+  const { isLoading: isFetching } = useQuery({
+    queryKey: ['insurance-providers', debouncedSearch],
+    queryFn: async ({ signal }) => {
+      const result = await fetchPayers?.(
+        {
+          search: debouncedSearch || undefined,
+          limit: PROVIDERS_PAGE_SIZE,
+          skip: 0,
+        },
+        signal,
+      );
+
+      const providers = (result as HealthPayer[]) ?? [];
+
+      skipRef.current = providers.length;
+      setAllProviders(providers);
+      setHasMore(providers.length >= PROVIDERS_PAGE_SIZE);
+
+      return providers;
+    },
+    refetchOnMount: true,
+    enabled: !!fetchPayers,
+  });
+
+  const loadMore = useCallback(async () => {
+    if (isLoadingMore || !hasMore) return;
+
+    setIsLoadingMore(true);
+    try {
+      const result = await fetchPayers?.({
+        search: debouncedSearch || undefined,
+        limit: PROVIDERS_PAGE_SIZE,
+        skip: skipRef.current,
+      });
+      const newProviders = (result as HealthPayer[]) ?? [];
+
+      setAllProviders((prev) => [...prev, ...newProviders]);
+      skipRef.current += newProviders.length;
+      setHasMore(newProviders.length >= PROVIDERS_PAGE_SIZE);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [isLoadingMore, hasMore, debouncedSearch, fetchPayers]);
+
+  return {
+    providers: allProviders,
+    isLoading: isFetching,
+    isLoadingMore,
+    hasMore,
+    loadMore,
+  };
+}
+
+function RequiredLabel({ children }: { children: ReactNode }) {
+  return (
+    <>
+      {children}{' '}
+      <Typography
+        data-asterisk
+        component='span'
+        color='error'
+        variant='subtitle2'
+        sx={{ fontSize: 'inherit' }}
+      >
+        ✽
+      </Typography>
+    </>
+  );
+}
+
+function HealthPayersInputContent({
+  value,
+  onChange,
+  fetchPayers,
+  disabled,
+  label = <RequiredLabel>Insurer</RequiredLabel>,
+  helperText = 'The company that provides your health insurance',
+  placeholder = 'Search...',
+  size,
+}: Readonly<Omit<HealthPayersInputProps, 'queryClient'>>) {
+  const [searchInput, setSearchInput] = useState('');
+  const { providers, isLoading, isLoadingMore, hasMore, loadMore } =
+    useHealthInsuranceProviders(searchInput, fetchPayers);
+  const listboxRef = useRef<HTMLUListElement | null>(null);
+
+  const handleListboxScroll = useCallback(
+    (event: React.UIEvent<HTMLUListElement>) => {
+      const listbox = event.currentTarget;
+      const isNearBottom =
+        listbox.scrollTop + listbox.clientHeight >= listbox.scrollHeight - 50;
+
+      if (isNearBottom && hasMore && !isLoadingMore) {
+        void loadMore();
+      }
+    },
+    [hasMore, isLoadingMore, loadMore],
+  );
+
+  const selectedPayer =
+    providers.find((p) => p.verifiedId === value?.verifiedId) ?? value ?? null;
+
+  return (
+    <Autocomplete
+      fullWidth
+      disabled={disabled}
+      options={providers}
+      loading={isLoading || isLoadingMore}
+      filterOptions={(x) => x}
+      value={selectedPayer?.verifiedId ? selectedPayer : null}
+      inputValue={searchInput}
+      onInputChange={(_, newInputValue) => {
+        setSearchInput(newInputValue);
+      }}
+      onChange={(_, newValue) => {
+        if (newValue) {
+          onChange?.({
+            name: newValue.name,
+            logoUrl: newValue.logoUrl,
+            verifiedId: newValue.verifiedId,
+          });
+        } else {
+          onChange?.(null);
+        }
+      }}
+      isOptionEqualToValue={(option, value) =>
+        !!option && !!value && option.verifiedId === value.verifiedId
+      }
+      getOptionLabel={(option) => option.name}
+      ListboxProps={{
+        ref: listboxRef,
+        onScroll: handleListboxScroll,
+      }}
+      renderOption={(props, option) => (
+        <Box component='li' {...props} key={option.verifiedId}>
+          <Stack direction='row' spacing={1.5} alignItems='center'>
+            <Avatar
+              src={option.logoUrl ?? undefined}
+              alt={option.name[0]?.toUpperCase()}
+              sx={{ width: 32, height: 32, bgcolor: 'primary.main' }}
+              slotProps={{
+                img: {
+                  onError: (e: React.SyntheticEvent<HTMLImageElement>) => {
+                    e.currentTarget.style.display = 'none';
+                  },
+                },
+              }}
+            >
+              {option.name[0]?.toUpperCase()}
+            </Avatar>
+            <Typography sx={{ textAlign: 'left' }}>{option.name}</Typography>
+          </Stack>
+        </Box>
+      )}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          helperText={helperText}
+          placeholder={placeholder}
+          size={size}
+          InputLabelProps={{ shrink: true }}
+          InputProps={
+            {
+              ...params.InputProps,
+              'data-mask-me': true,
+              endAdornment: params.InputProps.endAdornment,
+            } as any
+          }
+        />
+      )}
+    />
+  );
+}
+
+/**
+ * Standalone autocomplete for selecting a health insurance payer (insurer).
+ *
+ * Extracted from the 1-Click health insurance field so it can be reused on its
+ * own. Provide `fetchPayers` to supply the options (it receives
+ * `{ search, limit, skip }` and should return an array of payers); the component
+ * handles debounced search and infinite-scroll pagination internally.
+ *
+ * Self-contained: it provides its own React Query client unless `queryClient`
+ * is passed.
+ */
+export function HealthPayersInput({
+  queryClient,
+  ...props
+}: Readonly<HealthPayersInputProps>) {
+  const [internalQueryClient] = useState(
+    () =>
+      queryClient ??
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: Infinity,
+            retryDelay: 3000,
+            refetchOnReconnect: false,
+            refetchOnMount: false,
+            refetchOnWindowFocus: false,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={internalQueryClient}>
+      <HealthPayersInputContent {...props} />
+    </QueryClientProvider>
+  );
+}

--- a/src/components/form/HealthPayersInput/index.tsx
+++ b/src/components/form/HealthPayersInput/index.tsx
@@ -244,9 +244,8 @@ export function HealthPayersInput({
   queryClient,
   ...props
 }: Readonly<HealthPayersInputProps>) {
-  const [internalQueryClient] = useState(
+  const [defaultQueryClient] = useState(
     () =>
-      queryClient ??
       new QueryClient({
         defaultOptions: {
           queries: {
@@ -259,6 +258,13 @@ export function HealthPayersInput({
         },
       }),
   );
+
+  return (
+    <QueryClientProvider client={queryClient ?? defaultQueryClient}>
+      <HealthPayersInputContent {...props} />
+    </QueryClientProvider>
+  );
+}
 
   return (
     <QueryClientProvider client={internalQueryClient}>

--- a/src/components/form/HealthPayersInput/index.tsx
+++ b/src/components/form/HealthPayersInput/index.tsx
@@ -88,7 +88,9 @@ function useHealthInsuranceProviders(
         limit: PROVIDERS_PAGE_SIZE,
         skip: skipRef.current,
       });
-      const newProviders = Array.isArray(result) ? (result as HealthPayer[]) : [];
+      const newProviders = Array.isArray(result)
+        ? (result as HealthPayer[])
+        : [];
 
       setAllProviders((prev) => [...prev, ...newProviders]);
       skipRef.current += newProviders.length;
@@ -260,13 +262,6 @@ export function HealthPayersInput({
 
   return (
     <QueryClientProvider client={queryClient ?? defaultQueryClient}>
-      <HealthPayersInputContent {...props} />
-    </QueryClientProvider>
-  );
-}
-
-  return (
-    <QueryClientProvider client={internalQueryClient}>
       <HealthPayersInputContent {...props} />
     </QueryClientProvider>
   );

--- a/src/components/form/HealthPayersInput/index.tsx
+++ b/src/components/form/HealthPayersInput/index.tsx
@@ -67,13 +67,12 @@ function useHealthInsuranceProviders(
         signal,
       );
 
-      const providers = (result as HealthPayer[]) ?? [];
-
+      return Array.isArray(result) ? (result as HealthPayer[]) : [];
+    },
+    onSuccess: (providers) => {
       skipRef.current = providers.length;
       setAllProviders(providers);
       setHasMore(providers.length >= PROVIDERS_PAGE_SIZE);
-
-      return providers;
     },
     refetchOnMount: true,
     enabled: !!fetchPayers,

--- a/src/components/form/NewOneClickForm/react/ui/fields/input/healthInsurance.field.tsx
+++ b/src/components/form/NewOneClickForm/react/ui/fields/input/healthInsurance.field.tsx
@@ -1,91 +1,14 @@
-import { useCallback, useRef, useState } from 'react';
-import {
-  Autocomplete,
-  Avatar,
-  Box,
-  IconButton,
-  InputAdornment,
-  Stack,
-  TextField,
-  Typography,
-} from '@mui/material';
+import { IconButton, InputAdornment, Stack, Typography } from '@mui/material';
 import { Close } from '@mui/icons-material';
-import { useQuery } from '@tanstack/react-query';
-
-import { useDebounceValue } from '../../../../../../../hooks/useDebounceValue';
 
 import { MemberIdInput } from '../../../../../MemberIdInput';
+import { HealthPayersInput } from '../../../../../HealthPayersInput';
 
 import { HealthInsuranceValue } from '../../../../core/validations';
 
 import { useFormField } from '../../../core/field.hook';
 
 import { useOneClickForm } from '../../form.context';
-
-type Payer = HealthInsuranceValue['payer'];
-
-const PROVIDERS_PAGE_SIZE = 20;
-
-function useHealthInsuranceProviders(search: string) {
-  const { options } = useOneClickForm();
-  const debouncedSearch = useDebounceValue(search, 300);
-  const [allProviders, setAllProviders] = useState<Payer[]>([]);
-  const [hasMore, setHasMore] = useState(true);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const skipRef = useRef(0);
-
-  const { isLoading: isFetching } = useQuery({
-    queryKey: ['insurance-providers', debouncedSearch],
-    queryFn: async ({ signal }) => {
-      const result = await options.servicePaths.oneClickHealthProviderPayers?.(
-        {
-          search: debouncedSearch || undefined,
-          limit: PROVIDERS_PAGE_SIZE,
-          skip: 0,
-        },
-        signal,
-      );
-
-      const providers = (result as Payer[]) ?? [];
-
-      skipRef.current = providers.length;
-      setAllProviders(providers);
-      setHasMore(providers.length >= PROVIDERS_PAGE_SIZE);
-
-      return providers;
-    },
-    refetchOnMount: true,
-    enabled: !!options.servicePaths.oneClickHealthProviderPayers,
-  });
-
-  const loadMore = useCallback(async () => {
-    if (isLoadingMore || !hasMore) return;
-
-    setIsLoadingMore(true);
-    try {
-      const result = await options.servicePaths.oneClickHealthProviderPayers?.({
-        search: debouncedSearch || undefined,
-        limit: PROVIDERS_PAGE_SIZE,
-        skip: skipRef.current,
-      });
-      const newProviders = (result as Payer[]) ?? [];
-
-      setAllProviders((prev) => [...prev, ...newProviders]);
-      skipRef.current += newProviders.length;
-      setHasMore(newProviders.length >= PROVIDERS_PAGE_SIZE);
-    } finally {
-      setIsLoadingMore(false);
-    }
-  }, [isLoadingMore, hasMore, debouncedSearch, options.servicePaths]);
-
-  return {
-    providers: allProviders,
-    isLoading: isFetching,
-    isLoadingMore,
-    hasMore,
-    loadMore,
-  };
-}
 
 function RequiredLabel({ children }: { children: React.ReactNode }) {
   return (
@@ -105,27 +28,10 @@ function RequiredLabel({ children }: { children: React.ReactNode }) {
 }
 
 export function HealthInsuranceInputField({ fieldKey }: { fieldKey: string }) {
+  const { options } = useOneClickForm();
   const { field, setValue } = useFormField<'healthInsurance'>({
     key: fieldKey,
   });
-
-  const [searchInput, setSearchInput] = useState('');
-  const { providers, isLoading, isLoadingMore, hasMore, loadMore } =
-    useHealthInsuranceProviders(searchInput);
-  const listboxRef = useRef<HTMLUListElement | null>(null);
-
-  const handleListboxScroll = useCallback(
-    (event: React.UIEvent<HTMLUListElement>) => {
-      const listbox = event.currentTarget;
-      const isNearBottom =
-        listbox.scrollTop + listbox.clientHeight >= listbox.scrollHeight - 50;
-
-      if (isNearBottom && hasMore && !isLoadingMore) {
-        void loadMore();
-      }
-    },
-    [hasMore, isLoadingMore, loadMore],
-  );
 
   if (!field) return null;
 
@@ -137,32 +43,16 @@ export function HealthInsuranceInputField({ fieldKey }: { fieldKey: string }) {
     setValue({ ...item, ...patch });
   };
 
-  const selectedPayer =
-    providers.find((p) => p.verifiedId === item.payer.verifiedId) ?? item.payer;
-
   return (
     <Stack spacing={2}>
-      <Autocomplete
-        fullWidth
+      <HealthPayersInput
+        size='small'
         disabled={field.isDisabled}
-        options={providers}
-        loading={isLoading || isLoadingMore}
-        filterOptions={(x) => x}
-        value={selectedPayer.verifiedId ? selectedPayer : null}
-        inputValue={searchInput}
-        onInputChange={(_, newInputValue) => {
-          setSearchInput(newInputValue);
-        }}
-        onChange={(_, newValue) => {
-          if (newValue) {
-            updateItem({
-              payer: {
-                name: newValue.name,
-                logoUrl: newValue.logoUrl,
-                verifiedId: newValue.verifiedId,
-              },
-              memberId: '',
-            });
+        value={item.payer}
+        fetchPayers={options.servicePaths.oneClickHealthProviderPayers}
+        onChange={(payer) => {
+          if (payer) {
+            updateItem({ payer, memberId: '' });
           } else {
             updateItem({
               payer: { name: '', logoUrl: undefined, verifiedId: '' },
@@ -170,52 +60,6 @@ export function HealthInsuranceInputField({ fieldKey }: { fieldKey: string }) {
             });
           }
         }}
-        isOptionEqualToValue={(option, value) =>
-          !!option && !!value && option.verifiedId === value.verifiedId
-        }
-        getOptionLabel={(option) => option.name}
-        ListboxProps={{
-          ref: listboxRef,
-          onScroll: handleListboxScroll,
-        }}
-        renderOption={(props, option) => (
-          <Box component='li' {...props} key={option.verifiedId}>
-            <Stack direction='row' spacing={1.5} alignItems='center'>
-              <Avatar
-                src={option.logoUrl ?? undefined}
-                alt={option.name[0]?.toUpperCase()}
-                sx={{ width: 32, height: 32, bgcolor: 'primary.main' }}
-                slotProps={{
-                  img: {
-                    onError: (e: React.SyntheticEvent<HTMLImageElement>) => {
-                      e.currentTarget.style.display = 'none';
-                    },
-                  },
-                }}
-              >
-                {option.name[0]?.toUpperCase()}
-              </Avatar>
-              <Typography sx={{ textAlign: 'left' }}>{option.name}</Typography>
-            </Stack>
-          </Box>
-        )}
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            label={<RequiredLabel>Insurer</RequiredLabel>}
-            helperText='The company that provides your health insurance'
-            placeholder='Search...'
-            size='small'
-            InputLabelProps={{ shrink: true }}
-            InputProps={
-              {
-                ...params.InputProps,
-                'data-mask-me': true,
-                endAdornment: params.InputProps.endAdornment,
-              } as any
-            }
-          />
-        )}
       />
 
       <MemberIdInput

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -13,3 +13,5 @@ export * from './RadioOption';
 export * from './DefaultInput';
 export * from './AddressInput';
 export * from './NPIInput';
+export * from './MemberIdInput';
+export * from './HealthPayersInput';

--- a/src/stories/components/form/HealthPayersInput.stories.tsx
+++ b/src/stories/components/form/HealthPayersInput.stories.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Box, Stack, Typography } from '@mui/material';
+import { action } from '@storybook/addon-actions';
+
+import {
+  HealthPayersInput,
+  type HealthPayer,
+  type FetchHealthPayers,
+} from '../../../components/form/HealthPayersInput';
+
+// A static list of payers used to back the in-memory mock fetcher.
+const ALL_PAYERS: HealthPayer[] = [
+  { verifiedId: 'V1', name: 'Acme Health', logoUrl: null },
+  { verifiedId: 'V2', name: 'Acme Insurance', logoUrl: null },
+  { verifiedId: 'V3', name: 'Acme Care', logoUrl: null },
+];
+
+// In-memory mock that mimics the real payers endpoint: filters by `search`
+// and paginates with `limit`/`skip`, with a small artificial delay so the
+// loading state is visible.
+const mockFetchPayers: FetchHealthPayers = async (params) => {
+  const search = (params?.search ?? '').toLowerCase();
+  const limit = params?.limit ?? 20;
+  const skip = params?.skip ?? 0;
+
+  await new Promise((resolve) => setTimeout(resolve, 400));
+
+  const filtered = search
+    ? ALL_PAYERS.filter((payer) => payer.name.toLowerCase().includes(search))
+    : ALL_PAYERS;
+
+  return filtered.slice(skip, skip + limit);
+};
+
+const HealthPayersInputWithState = (args: any): React.JSX.Element => {
+  const [value, setValue] = useState<HealthPayer | null>(args.value ?? null);
+
+  return (
+    <Stack spacing={2} sx={{ width: 400 }}>
+      <HealthPayersInput
+        {...args}
+        value={value}
+        onChange={(payer) => {
+          setValue(payer);
+          action('onChange')(payer);
+        }}
+      />
+      <Box>
+        <Typography variant='body2' color='text.secondary' gutterBottom>
+          Selected payer:
+        </Typography>
+        <pre
+          style={{
+            fontSize: '0.875rem',
+            background: '#f5f5f5',
+            padding: '8px',
+            borderRadius: '4px',
+            margin: 0,
+          }}
+        >
+          {JSON.stringify(value, null, 2)}
+        </pre>
+      </Box>
+    </Stack>
+  );
+};
+
+const meta = {
+  title: 'Components/form/HealthPayersInput',
+  component: HealthPayersInput,
+  render: (args) => <HealthPayersInputWithState {...args} />,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    label: { control: 'text' },
+    helperText: { control: 'text' },
+    placeholder: { control: 'text' },
+    size: { control: 'select', options: ['small', 'medium'] },
+    disabled: { control: 'boolean' },
+  },
+} satisfies Meta<typeof HealthPayersInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    value: null,
+    disabled: false,
+    fetchPayers: mockFetchPayers,
+  },
+};
+
+export const Prefilled: Story = {
+  args: {
+    value: { verifiedId: 'V1', name: 'Acme Health', logoUrl: null },
+    disabled: false,
+    fetchPayers: mockFetchPayers,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    value: { verifiedId: 'V2', name: 'Acme Insurance', logoUrl: null },
+    disabled: true,
+    fetchPayers: mockFetchPayers,
+  },
+};


### PR DESCRIPTION
## Summary
Extracts the health insurance payer (insurer) autocomplete out of the 1-Click health insurance field into a standalone, reusable `HealthPayersInput` component and exports it (along with `MemberIdInput`) from the form package.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
