### PR TITLE
feat: add phone field with formatting and display logic

### DIFF
--- a/src/components/form/NewOneClickForm/core/fields/phone.ts
+++ b/src/components/form/NewOneClickForm/core/fields/phone.ts
@@ -1,4 +1,6 @@
 import { phoneSchema } from '../validations';
+import { phoneFormat } from '../formats';
+
 import type { TextFieldDefinition, ExtractedFieldValueType } from './types';
 
 const phoneKey = 'phone';
@@ -11,6 +13,7 @@ export const phone = {
     placeholder: '(555) 123-4567',
   },
   zodSchema: phoneSchema,
+  format: phoneFormat,
 };
 
 declare module '../declarations' {

--- a/src/components/form/NewOneClickForm/core/formats/index.ts
+++ b/src/components/form/NewOneClickForm/core/formats/index.ts
@@ -1,5 +1,6 @@
 export * from './address.format';
 export * from './date.format';
 export * from './healthInsurance.format';
+export * from './phone.format';
 export * from './ssn.format';
 export * from './state.format';

--- a/src/components/form/NewOneClickForm/core/formats/phone.format.ts
+++ b/src/components/form/NewOneClickForm/core/formats/phone.format.ts
@@ -1,0 +1,12 @@
+import { parseToPhoneNational } from '../../../../../utils/phone';
+
+export const phoneFormat = (value: string): string => {
+  if (!value) return value;
+  // Render E.164 in a human-readable national format (e.g. "+1 (212) 555-0010").
+  // Falls back to the raw value if it can't be parsed.
+  try {
+    return parseToPhoneNational(value);
+  } catch {
+    return value;
+  }
+};

--- a/src/components/form/NewOneClickForm/react/ui/fields/field-order.ts
+++ b/src/components/form/NewOneClickForm/react/ui/fields/field-order.ts
@@ -1,0 +1,43 @@
+import { credentialKeys } from '../../../core/fields';
+import type { FormField } from '../../../core/form';
+
+/**
+ * Computes the ordered list of field keys to render.
+ *
+ * The phone field is hidden by default. When `showPhone` is enabled, the phone
+ * is surfaced and positioned between the name and address fields (per product
+ * rule: a phone that was not provided as input — e.g. sourced from autofill —
+ * must be shown so the user can confirm it). When `showPhone` is disabled (the
+ * default), the phone field is omitted entirely, preserving existing behavior.
+ */
+export function getDisplayFieldKeys(
+  fields: Record<string, FormField>,
+  { showPhone }: { showPhone?: boolean },
+): string[] {
+  const keys = Object.keys(fields);
+  const hasPhone = keys.includes(credentialKeys.phone);
+
+  // Phone hidden (default) or not present — drop it and keep natural order.
+  if (!showPhone || !hasPhone) {
+    return keys.filter((key) => key !== credentialKeys.phone);
+  }
+
+  // Pull phone out of its natural slot and re-insert it between name and
+  // address: right after name when present, otherwise just before address,
+  // otherwise append.
+  const ordered = keys.filter((key) => key !== credentialKeys.phone);
+  const fullNameIndex = ordered.indexOf(credentialKeys.fullName);
+  const addressIndex = ordered.indexOf(credentialKeys.address);
+
+  let insertAt: number;
+  if (fullNameIndex !== -1) {
+    insertAt = fullNameIndex + 1;
+  } else if (addressIndex !== -1) {
+    insertAt = addressIndex;
+  } else {
+    insertAt = ordered.length;
+  }
+
+  ordered.splice(insertAt, 0, credentialKeys.phone);
+  return ordered;
+}

--- a/src/components/form/NewOneClickForm/react/ui/fields/input/field.tsx
+++ b/src/components/form/NewOneClickForm/react/ui/fields/input/field.tsx
@@ -13,7 +13,10 @@ import {
   FieldSectionTitle,
 } from '../style';
 
+import { getDisplayFieldKeys } from '../field-order';
+
 import { AddressInputField } from './address.field';
+import { PhoneInputField } from './phone.field';
 import { TextInputField } from './text.field';
 import { SelectInputField } from './select.field';
 import { SSNInputField } from './ssn.field';
@@ -47,6 +50,16 @@ function FieldContainer({ fieldKey }: { fieldKey: string }) {
 
     return null;
   };
+
+  // Custom render for the phone field — uses the dedicated phone input
+  // (country selector + masking) instead of the generic text input.
+  if (field?.schema?.key === credentialKeys.phone) {
+    return (
+      <FieldRowContainer fieldKey={fieldKey}>
+        <PhoneInputField fieldKey={fieldKey} />
+      </FieldRowContainer>
+    );
+  }
 
   // Custom render for the health insurance field as a section with formatted value
   if (field?.schema?.key === credentialKeys.healthInsurance) {
@@ -115,14 +128,15 @@ function FieldContainer({ fieldKey }: { fieldKey: string }) {
 export function EditFields() {
   const context = useOneClickForm();
   const { fields } = context.formContext.state.form;
+  const fieldKeys = getDisplayFieldKeys(fields, {
+    showPhone: context.options.features.field?.phone?.show,
+  });
 
   return (
     <Stack spacing={2} sx={{ width: '100%' }}>
-      {Object.entries(fields).map(([fieldKey, field]) => {
-        // We don't want to render the phone field in edit mode
-        if (field.schema.key === credentialKeys.phone) return null;
-        return <FieldContainer key={fieldKey} fieldKey={fieldKey} />;
-      })}
+      {fieldKeys.map((fieldKey) => (
+        <FieldContainer key={fieldKey} fieldKey={fieldKey} />
+      ))}
     </Stack>
   );
 }

--- a/src/components/form/NewOneClickForm/react/ui/fields/input/phone.field.tsx
+++ b/src/components/form/NewOneClickForm/react/ui/fields/input/phone.field.tsx
@@ -1,0 +1,34 @@
+import { Box } from '@mui/material';
+
+import { PhoneInput } from '../../../../../PhoneInput';
+
+import { useFormField } from '../../../core/field.hook';
+
+import { FieldLabel } from './label';
+
+export function PhoneInputField({ fieldKey }: { fieldKey: string }) {
+  const { field, setValue } = useFormField<'phone'>({ key: fieldKey });
+
+  if (!field) return null;
+
+  return (
+    <Box width='100%'>
+      <PhoneInput
+        variant='outlined'
+        size='small'
+        label={<FieldLabel fieldKey={fieldKey} />}
+        value={field.value || ''}
+        onChange={(value) => {
+          if (field.isDisabled) return;
+          setValue(value);
+        }}
+        error={!field.isValid}
+        helperText={field.description}
+        disabled={field.isDisabled}
+        shouldHaveClearButton
+        shouldHaveSelectCountryButton={false}
+        InputLabelProps={{ shrink: true }}
+      />
+    </Box>
+  );
+}

--- a/src/components/form/NewOneClickForm/react/ui/fields/readonly/field.tsx
+++ b/src/components/form/NewOneClickForm/react/ui/fields/readonly/field.tsx
@@ -12,6 +12,8 @@ import {
   FieldSectionTitle,
   FieldSectionContent,
 } from '../style';
+import { getDisplayFieldKeys } from '../field-order';
+
 import { MultiField } from './multi.field';
 import { SingleField } from './single.field';
 import { HealthInsuranceField } from './healthInsurance.field';
@@ -99,6 +101,9 @@ function FieldContainer({ fieldKey }: { fieldKey: string }) {
 export function ReadonlyFields() {
   const context = useOneClickForm();
   const { fields } = context.formContext.state.form;
+  const fieldKeys = getDisplayFieldKeys(fields, {
+    showPhone: context.options.features.field?.phone?.show,
+  });
 
   return (
     <Stack
@@ -115,11 +120,9 @@ export function ReadonlyFields() {
         context.setEditMode(true);
       }}
     >
-      {Object.entries(fields).map(([fieldKey, field]) => {
-        // Phone credential should not be rendered
-        if (field.schema.key === credentialKeys.phone) return null;
-        return <FieldContainer key={fieldKey} fieldKey={fieldKey} />;
-      })}
+      {fieldKeys.map((fieldKey) => (
+        <FieldContainer key={fieldKey} fieldKey={fieldKey} />
+      ))}
     </Stack>
   );
 }

--- a/src/components/form/NewOneClickForm/react/ui/form.context.tsx
+++ b/src/components/form/NewOneClickForm/react/ui/form.context.tsx
@@ -15,6 +15,15 @@ type OneClickOptionFeatures = {
       /** When true, masks the year portion of the DOB field as ••••. */
       redactYear?: boolean;
     };
+    phone?: {
+      /**
+       * When true, shows the phone field in the form, positioned between the
+       * name and address fields. Phone is hidden by default; enable this when
+       * the phone was not provided as input (e.g. sourced from autofill) so the
+       * user can still see and confirm it.
+       */
+      show?: boolean;
+    };
   };
 };
 

--- a/tests/components/form/NewOneClickForm/core/formats/phone.format.test.ts
+++ b/tests/components/form/NewOneClickForm/core/formats/phone.format.test.ts
@@ -1,0 +1,13 @@
+import { describe, test, expect } from 'vitest';
+
+import { phoneFormat } from '../../../../../../src/components/form/NewOneClickForm/core/formats/phone.format';
+
+describe('phoneFormat', () => {
+  test('formats a US E.164 number in national format', () => {
+    expect(phoneFormat('+12125550010')).toBe('+1 (212) 555-0010');
+  });
+
+  test('returns an empty string unchanged', () => {
+    expect(phoneFormat('')).toBe('');
+  });
+});

--- a/tests/components/form/NewOneClickForm/react/ui/fields/field-order.test.ts
+++ b/tests/components/form/NewOneClickForm/react/ui/fields/field-order.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect } from 'vitest';
+
+import { FormBuilder } from '../../../../../../../src/components/form/NewOneClickForm/core/form/formBuilder';
+import { getDisplayFieldKeys } from '../../../../../../../src/components/form/NewOneClickForm/react/ui/fields/field-order';
+import type { CredentialRequest } from '../../../../../../../src/components/form/NewOneClickForm/types';
+
+const buildFields = (requests: CredentialRequest[]) =>
+  new FormBuilder().createFromCredentialAndRequests([], requests).fields;
+
+const request = (type: string): CredentialRequest => ({
+  type,
+  allowUserInput: true,
+  mandatory: 'no',
+  multi: false,
+});
+
+describe('getDisplayFieldKeys', () => {
+  test('omits phone by default (showPhone falsy)', () => {
+    const fields = buildFields([
+      request('FullNameCredential'),
+      request('PhoneCredential'),
+      request('AddressCredential'),
+    ]);
+
+    expect(getDisplayFieldKeys(fields, {})).toEqual(['fullName', 'address']);
+    expect(getDisplayFieldKeys(fields, { showPhone: false })).toEqual([
+      'fullName',
+      'address',
+    ]);
+  });
+
+  test('places phone between name and address when showPhone is true', () => {
+    const fields = buildFields([
+      request('FullNameCredential'),
+      // Phone is requested last to prove it gets re-positioned, not left in place.
+      request('AddressCredential'),
+      request('PhoneCredential'),
+    ]);
+
+    expect(getDisplayFieldKeys(fields, { showPhone: true })).toEqual([
+      'fullName',
+      'phone',
+      'address',
+    ]);
+  });
+
+  test('falls back to just before address when name is absent', () => {
+    const fields = buildFields([
+      request('AddressCredential'),
+      request('PhoneCredential'),
+    ]);
+
+    expect(getDisplayFieldKeys(fields, { showPhone: true })).toEqual([
+      'phone',
+      'address',
+    ]);
+  });
+
+  test('appends phone when neither name nor address is present', () => {
+    const fields = buildFields([
+      request('BirthDateCredential'),
+      request('PhoneCredential'),
+    ]);
+
+    expect(getDisplayFieldKeys(fields, { showPhone: true })).toEqual([
+      'birthDate',
+      'phone',
+    ]);
+  });
+
+  test('is a no-op when there is no phone field, even if showPhone is true', () => {
+    const fields = buildFields([
+      request('FullNameCredential'),
+      request('AddressCredential'),
+    ]);
+
+    expect(getDisplayFieldKeys(fields, { showPhone: true })).toEqual([
+      'fullName',
+      'address',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
Adds an optional phone field to the `NewOneClickForm`, gated behind a `field.phone.show` feature flag. When enabled, the phone is rendered (with country selector + masking on input, national-format display on read) and positioned between the name and address fields; when disabled, behavior is unchanged.

## Changes
- Add `phoneFormat` to render E.164 numbers in human-readable national format (e.g. `+1 (212) 555-0010`), falling back to the raw value when unparseable.
- Add `getDisplayFieldKeys` helper that computes field render order: omits phone by default, and when `showPhone` is set, re-positions phone after name / before address (with sensible fallbacks).
- Wire the new helper into both `EditFields` and `ReadonlyFields`, replacing the previous hardcoded "always skip phone" logic.
- Add `PhoneInputField` component using the dedicated `PhoneInput` (country selector hidden, masking + clear button enabled) for edit mode.
- Attach `phoneFormat` to the phone field definition and export it from the formats barrel.
- Add `field.phone.show` option to `OneClickOptionFeatures` in the form context.
- Add unit tests for `phoneFormat` and `getDisplayFieldKeys` (ordering, fallbacks, and no-op cases).

## Testing
- Added Vitest unit tests covering `phoneFormat` (US E.164 → national, empty string) and `getDisplayFieldKeys` (phone omitted by default, positioned between name/address when shown, fallback to before-address when name absent, appended when neither present, no-op when no phone field).
- Run `npm run test`.
- Manually verify in Storybook: with `field.phone.show` disabled the form is unchanged; with it enabled the phone appears between name and address in both edit and read-only views and displays in national format.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [x] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
