### PR TITLE
feat: implement WCAG AA contrast adjustments in theme and utility functions

### DIFF
--- a/src/components/chart/OverviewBigNumbers/OverviewBigNumbers.tsx
+++ b/src/components/chart/OverviewBigNumbers/OverviewBigNumbers.tsx
@@ -2,7 +2,6 @@ import { Stack } from '@mui/material';
 import type { SxProps } from '@mui/material';
 
 import { BigNumber } from '..';
-import { green } from '../../../styles/colors';
 import {
   formatNumberRounded,
   formatCurrency,
@@ -32,7 +31,7 @@ export interface OverviewBigNumbersProps {
   rateCard?: BigNumberCardOverride;
 }
 
-const defaultSx: SxProps = { color: green };
+const defaultSx: SxProps = { color: 'primary.main' };
 
 export function OverviewBigNumbers({
   metrics,

--- a/src/stories/styles/WcagAAContrast.stories.tsx
+++ b/src/stories/styles/WcagAAContrast.stories.tsx
@@ -1,0 +1,268 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Box, Stack, ThemeProvider, Typography } from '@mui/material';
+
+import { theme } from '../../styles/theme';
+import { colors } from '../../styles/colors';
+import { getContrastRatio } from '../../utils/color';
+import { Button } from '../../components';
+
+// A palette picked the way a brand admin might - for looks, not contrast - so the effect of
+// `wcagAAEnabled` is visible. `secondary` and `error` already pass AA and are left untouched;
+// `primary` (reusing the shipped `warning` yellow) fails, so both its `main` (against the page
+// background) and `contrastText` (against the resulting `main`) get corrected - the fill color
+// itself shifts, trading exact brand-hue fidelity for guaranteed readability everywhere `main`
+// is read, including outside MUI's styling system entirely. `text.secondary` is overridden to
+// `colors.grey` (the same grey the real `neutral` color uses) to demonstrate the fix for plain
+// body text on the page background too (no colored box involved).
+const riskyPalette = {
+  primary: {
+    main: colors.yellow,
+    light: colors.yellow,
+    dark: colors.darkYellow,
+    contrastText: colors.white,
+  },
+  secondary: {
+    main: colors.blue,
+    light: colors.lightBlue,
+    dark: colors.darkBlue,
+    contrastText: colors.white,
+  },
+  error: {
+    main: colors.red,
+    light: colors.lightRed,
+    dark: colors.darkRed,
+    contrastText: colors.white,
+  },
+  text: {
+    secondary: colors.grey,
+  },
+} as const;
+
+const PALETTE_KEYS = ['primary', 'secondary', 'error'] as const;
+
+interface ContrastReportProps {
+  wcagAAEnabled: boolean;
+}
+
+interface RatioLabelProps {
+  ratio: number;
+}
+
+function RatioLabel({ ratio }: Readonly<RatioLabelProps>) {
+  const passesAA = ratio >= 4.5;
+  return (
+    <Typography
+      variant='body2'
+      sx={{ color: passesAA ? 'success.dark' : 'error.main' }}
+    >
+      {ratio.toFixed(2)}:1 — {passesAA ? 'passes AA' : 'fails AA'}
+    </Typography>
+  );
+}
+
+function ContrastReport({ wcagAAEnabled }: Readonly<ContrastReportProps>) {
+  const demoTheme = theme({
+    primaryFontFace: { style: { fontFamily: 'sans-serif' } },
+    wcagAAEnabled,
+    palette: riskyPalette as any,
+  });
+  const textSecondaryRatio = getContrastRatio(
+    demoTheme.palette.text.secondary,
+    demoTheme.palette.background.default,
+  );
+
+  return (
+    <ThemeProvider theme={demoTheme}>
+      <Box sx={{ p: 2, minWidth: 280, backgroundColor: 'background.default' }}>
+        <Typography variant='overline' color='text.primary'>
+          wcagAAEnabled: {String(wcagAAEnabled)}
+        </Typography>
+        <Stack spacing={1.5} sx={{ mt: 1 }}>
+          {PALETTE_KEYS.map((key) => {
+            const paletteColor = demoTheme.palette[key];
+            const ratio = getContrastRatio(
+              paletteColor.main,
+              paletteColor.contrastText,
+            );
+
+            return (
+              <Stack key={key} direction='row' spacing={2} alignItems='center'>
+                <Button color={key} variant='contained' sx={{ width: 140 }}>
+                  {key}
+                </Button>
+                <RatioLabel ratio={ratio} />
+              </Stack>
+            );
+          })}
+          <Stack direction='row' spacing={2} alignItems='center'>
+            <Typography
+              variant='body1'
+              color='text.secondary'
+              sx={{ width: 140 }}
+            >
+              Secondary text
+            </Typography>
+            <RatioLabel ratio={textSecondaryRatio} />
+          </Stack>
+        </Stack>
+      </Box>
+    </ThemeProvider>
+  );
+}
+
+// The colors this package actually ships in `theme.ts` today - no palette override. Several
+// of these already fail AA (primary/success at 2.54:1, warning at 1.48:1, info at 2.23:1,
+// neutral/neutralContrast against the page background), which `wcagAAEnabled` corrects.
+const FILL_KEYS = [
+  'primary',
+  'secondary',
+  'error',
+  'warning',
+  'success',
+  'info',
+] as const;
+const FOREGROUND_KEYS = [
+  'neutral',
+  'neutralContrast',
+  'warningContrast',
+  'infoContrast',
+  'dangerContrast',
+] as const;
+
+function RealPaletteReport({ wcagAAEnabled }: Readonly<ContrastReportProps>) {
+  const demoTheme = theme({
+    primaryFontFace: { style: { fontFamily: 'sans-serif' } },
+    wcagAAEnabled,
+  });
+  const backgroundDefault = demoTheme.palette.background.default;
+  const disabledRatio = getContrastRatio(
+    demoTheme.palette.text.disabled,
+    backgroundDefault,
+  );
+
+  return (
+    <ThemeProvider theme={demoTheme}>
+      <Box sx={{ p: 2, minWidth: 320, backgroundColor: 'background.default' }}>
+        <Typography variant='overline' color='text.primary'>
+          wcagAAEnabled: {String(wcagAAEnabled)} (real base palette)
+        </Typography>
+        <Stack spacing={1.5} sx={{ mt: 1 }}>
+          {FILL_KEYS.map((key) => {
+            const paletteColor = demoTheme.palette[key];
+            const ratio = getContrastRatio(
+              paletteColor.main,
+              paletteColor.contrastText,
+            );
+            return (
+              <Stack key={key} direction='row' spacing={2} alignItems='center'>
+                <Button color={key} variant='contained' sx={{ width: 160 }}>
+                  {key}
+                </Button>
+                <RatioLabel ratio={ratio} />
+              </Stack>
+            );
+          })}
+          {FILL_KEYS.map((key) => {
+            const paletteColor = demoTheme.palette[key];
+            // `variant="text"` draws `main` directly as the text color, with no
+            // `contrastText` pairing involved - so this is checked against the page
+            // background instead. When enabled, `main` itself is already the corrected
+            // value (see `applyWcagAAContrast`), so no extra handling is needed here.
+            const ratio = getContrastRatio(paletteColor.main, backgroundDefault);
+            return (
+              <Stack
+                key={`${key}-text`}
+                direction='row'
+                spacing={2}
+                alignItems='center'
+              >
+                <Button color={key} variant='text' sx={{ width: 160 }}>
+                  {key} (text)
+                </Button>
+                <RatioLabel ratio={ratio} />
+              </Stack>
+            );
+          })}
+          {FOREGROUND_KEYS.map((key) => {
+            const paletteColor = (demoTheme.palette as any)[key];
+            const ratio = getContrastRatio(paletteColor.main, backgroundDefault);
+            return (
+              <Stack key={key} direction='row' spacing={2} alignItems='center'>
+                <Typography
+                  sx={{ width: 160, color: `${key}.main`, fontWeight: 700 }}
+                >
+                  {key}
+                </Typography>
+                <RatioLabel ratio={ratio} />
+              </Stack>
+            );
+          })}
+          <Stack direction='row' spacing={2} alignItems='center'>
+            <Typography
+              variant='body1'
+              color='text.disabled'
+              sx={{ width: 160 }}
+            >
+              Disabled text
+            </Typography>
+            <RatioLabel ratio={disabledRatio} />
+          </Stack>
+        </Stack>
+      </Box>
+    </ThemeProvider>
+  );
+}
+
+const meta = {
+  title: 'Styles/WCAG AA Contrast',
+  component: ContrastReport,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    wcagAAEnabled: { control: 'boolean' },
+  },
+} satisfies Meta<typeof ContrastReport>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// theme({ wcagAAEnabled: false }) - `primary`'s white contrastText fails AA against its
+// pale yellow main.
+export const Disabled: Story = {
+  args: {
+    wcagAAEnabled: false,
+  },
+};
+
+// theme({ wcagAAEnabled: true }) - the same palette, but `primary`'s `main` is darkened
+// against the page background, then its `contrastText` is re-checked against the new `main`.
+// Colors already compliant are left unchanged.
+export const Enabled: Story = {
+  args: {
+    wcagAAEnabled: true,
+  },
+};
+
+export const SideBySide: StoryObj = {
+  render: () => (
+    <Stack direction='row' spacing={4}>
+      <ContrastReport wcagAAEnabled={false} />
+      <ContrastReport wcagAAEnabled={true} />
+    </Stack>
+  ),
+};
+
+// Same toggle, but against this package's actual `theme()` defaults - no palette override.
+// `primary`/`success`/`warning`/`info`/`neutral`/`neutralContrast` currently fail AA; enabling
+// the flag corrects them while leaving the already-compliant ones untouched.
+export const RealPalette: StoryObj = {
+  render: () => (
+    <Stack direction='row' spacing={4}>
+      <RealPaletteReport wcagAAEnabled={false} />
+      <RealPaletteReport wcagAAEnabled={true} />
+    </Stack>
+  ),
+};

--- a/src/stories/styles/WcagAAContrast.stories.tsx
+++ b/src/stories/styles/WcagAAContrast.stories.tsx
@@ -169,7 +169,10 @@ function RealPaletteReport({ wcagAAEnabled }: Readonly<ContrastReportProps>) {
             // `contrastText` pairing involved - so this is checked against the page
             // background instead. When enabled, `main` itself is already the corrected
             // value (see `applyWcagAAContrast`), so no extra handling is needed here.
-            const ratio = getContrastRatio(paletteColor.main, backgroundDefault);
+            const ratio = getContrastRatio(
+              paletteColor.main,
+              backgroundDefault,
+            );
             return (
               <Stack
                 key={`${key}-text`}
@@ -186,7 +189,10 @@ function RealPaletteReport({ wcagAAEnabled }: Readonly<ContrastReportProps>) {
           })}
           {FOREGROUND_KEYS.map((key) => {
             const paletteColor = (demoTheme.palette as any)[key];
-            const ratio = getContrastRatio(paletteColor.main, backgroundDefault);
+            const ratio = getContrastRatio(
+              paletteColor.main,
+              backgroundDefault,
+            );
             return (
               <Stack key={key} direction='row' spacing={2} alignItems='center'>
                 <Typography

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,6 +1,7 @@
-import { createTheme, ThemeOptions } from '@mui/material';
+import { createTheme, Theme, ThemeOptions } from '@mui/material';
 import { colors } from './colors';
 import { typography } from './typography';
+import { ensureWcagAAContrast } from '../utils/color';
 
 declare module '@mui/material/Button' {
   interface ButtonPropsColorOverrides {
@@ -48,10 +49,108 @@ declare module '@mui/material' {
 
 interface ThemeOptionsProps extends ThemeOptions {
   primaryFontFace: Record<string, any>;
+  /**
+   * When true, adjusts every palette color's `main`/`dark` (and fill colors'
+   * `contrastText`) plus `text.primary`/`text.secondary`/`text.disabled` so they meet the
+   * WCAG level AA contrast ratio - see `applyWcagAAContrast`. `light` is left untouched, since
+   * it's also used as a background/overlay tint. This can shift a color away from its
+   * original hue (e.g. a `contained` button's fill, or its hover state), trading exact
+   * brand-color fidelity for guaranteed readability everywhere these are used, including
+   * direct `theme.palette.x.main`/`.dark` reads in app code that a theme-only fix can't
+   * otherwise reach. Off by default to preserve existing palettes.
+   */
+  wcagAAEnabled?: boolean;
 }
 
-export const theme = ({ primaryFontFace, ...options }: ThemeOptionsProps) =>
-  createTheme({
+/**
+ * Checks whether a value is a MUI-style palette color (has a `main` string), covering both
+ * fill colors (e.g. `primary`, which also has `contrastText`) and foreground-only accent
+ * colors (e.g. `neutral`, `infoContrast`, which don't).
+ * @param value The value to check.
+ * @returns Whether the value is a palette color.
+ */
+function isPaletteColor(value: unknown): value is {
+  main: string;
+  dark?: string;
+  contrastText?: string;
+} {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).main === 'string'
+  );
+}
+
+/**
+ * Adjusts every palette color's `main`/`dark` in-place so each meets WCAG level AA contrast
+ * against the page background - this covers both fill colors (`primary`, `warning`, ...) and
+ * foreground-only accent colors (`neutral`, `infoContrast`, ...) alike, since either can be
+ * read directly as a text/icon color in both this package's components and consuming apps
+ * (not just as a `contained` button's background, or `dark` as its hover background). Fill
+ * colors then have their `contrastText` re-checked against the (possibly shifted) `main`.
+ * `text.primary`/`text.secondary`/`text.disabled` are adjusted against the page background
+ * too.
+ *
+ * `light` is deliberately left untouched - unlike `main`/`dark`, it's also used as a
+ * background/overlay tint (e.g. `alpha(palette.secondary.light, 0.4)` as a `bgcolor`), where
+ * shifting it for foreground-safety would just be an unwanted color change with no
+ * accessibility benefit.
+ *
+ * This can shift a color away from its original hue - e.g. a `contained` button's fill color
+ * may no longer exactly match the configured brand color - trading color fidelity for
+ * guaranteed readability everywhere it's used, including direct `theme.palette.x.main`
+ * (or `.dark`) reads in app code that no theme-level component override could otherwise
+ * reach.
+ * @param builtTheme The theme to adjust.
+ * @returns The same theme, with contrast-adjusted colors.
+ */
+function applyWcagAAContrast(builtTheme: Theme) {
+  const { palette } = builtTheme;
+  const pageBackground = palette.background.default;
+
+  palette.text.primary = ensureWcagAAContrast(
+    palette.text.primary,
+    pageBackground,
+  );
+  palette.text.secondary = ensureWcagAAContrast(
+    palette.text.secondary,
+    pageBackground,
+  );
+  palette.text.disabled = ensureWcagAAContrast(
+    palette.text.disabled,
+    pageBackground,
+  );
+
+  Object.values(palette).forEach((paletteColor) => {
+    if (isPaletteColor(paletteColor)) {
+      paletteColor.main = ensureWcagAAContrast(
+        paletteColor.main,
+        pageBackground,
+      );
+      if (typeof paletteColor.dark === 'string') {
+        paletteColor.dark = ensureWcagAAContrast(
+          paletteColor.dark,
+          pageBackground,
+        );
+      }
+      if (typeof paletteColor.contrastText === 'string') {
+        paletteColor.contrastText = ensureWcagAAContrast(
+          paletteColor.contrastText,
+          paletteColor.main,
+        );
+      }
+    }
+  });
+
+  return builtTheme;
+}
+
+export const theme = ({
+  primaryFontFace,
+  wcagAAEnabled,
+  ...options
+}: ThemeOptionsProps) => {
+  const builtTheme = createTheme({
     breakpoints: {
       values: {
         xs: 0,
@@ -343,3 +442,6 @@ export const theme = ({ primaryFontFace, ...options }: ThemeOptionsProps) =>
     },
     ...options,
   });
+
+  return wcagAAEnabled ? applyWcagAAContrast(builtTheme) : builtTheme;
+};

--- a/src/utils/color/index.ts
+++ b/src/utils/color/index.ts
@@ -53,6 +53,97 @@ export const mix = (color1: string, color2: string, amount: number) => {
 };
 
 /**
+ * Resolves how a (possibly semi-transparent) color actually renders on top of `background`,
+ * so contrast can be measured against what's visibly on screen rather than the raw color
+ * (e.g. MUI's default `text.secondary` is `rgba(0,0,0,0.6)`, which is much lighter than
+ * black once composited over a background).
+ * @param color The color to resolve, which may have an alpha channel.
+ * @param background The color it's rendered on top of.
+ * @returns The equivalent fully opaque color.
+ */
+const flattenOverBackground = (color: string, background: string) => {
+  const parsedColor = tinycolor(color);
+  const alphaValue = parsedColor.getAlpha();
+  if (alphaValue >= 1) {
+    return parsedColor.toHexString();
+  }
+  return mix(
+    background,
+    parsedColor.setAlpha(1).toHexString(),
+    alphaValue * 100,
+  );
+};
+
+/**
+ * Gets the WCAG contrast ratio between two colors, compositing away any alpha channel first
+ * (each color is flattened over the other) so translucent colors - e.g. MUI's default
+ * `rgba(0,0,0,0.6)` `text.secondary` - are measured as they actually render, not as if opaque.
+ * @param color1 The first color, which may have an alpha channel.
+ * @param color2 The second color, which may have an alpha channel.
+ * @returns A ratio from 1 (no contrast) to 21 (max contrast, black on white).
+ */
+export const getContrastRatio = (color1: string, color2: string) => {
+  return tinycolor.readability(
+    flattenOverBackground(color1, color2),
+    flattenOverBackground(color2, color1),
+  );
+};
+
+/**
+ * Checks whether a foreground/background pair meets the WCAG 2 level AA contrast requirement
+ * (4.5:1, or 3:1 for large-scale text).
+ * @param foreground The foreground (e.g. text) color.
+ * @param background The background color it's shown against.
+ * @param isLargeText Large-scale text (18pt+, or bold 14pt+) only needs a 3:1 ratio.
+ * @returns Whether the pair meets WCAG level AA.
+ */
+export const meetsWcagAA = (
+  foreground: string,
+  background: string,
+  isLargeText: boolean = false,
+) => {
+  return getContrastRatio(foreground, background) >= (isLargeText ? 3 : 4.5);
+};
+
+/**
+ * Adjusts `foreground` towards whichever of black or white contrasts better with `background`,
+ * until the pair meets the WCAG level AA contrast ratio. Returned unchanged if it already
+ * meets AA (this includes pure black/white already paired with a contrasting background, and
+ * semi-transparent colors like MUI's default `text.secondary` that are already readable once
+ * composited over `background`).
+ * @param foreground The color to make readable against `background`. May be semi-transparent.
+ * @param background The color `foreground` is shown against.
+ * @param isLargeText Large-scale text (18pt+, or bold 14pt+) only needs a 3:1 ratio.
+ * @returns `foreground` unchanged if it already meets AA, otherwise an opaque
+ * darkened/lightened color that does.
+ */
+export const ensureWcagAAContrast = (
+  foreground: string,
+  background: string,
+  isLargeText: boolean = false,
+) => {
+  if (meetsWcagAA(foreground, background, isLargeText)) {
+    return foreground;
+  }
+
+  const effectiveForeground = flattenOverBackground(foreground, background);
+  const preferBlack =
+    getContrastRatio('#000000', background) >=
+    getContrastRatio('#ffffff', background);
+
+  for (let amount = 5; amount <= 100; amount += 5) {
+    const adjusted = preferBlack
+      ? darken(effectiveForeground, amount)
+      : lighten(effectiveForeground, amount);
+    if (meetsWcagAA(adjusted, background, isLargeText)) {
+      return adjusted;
+    }
+  }
+
+  return preferBlack ? '#000000' : '#ffffff';
+};
+
+/**
  * Get the color theme from a primary color. Used in the demo.
  * @param primaryColor The primary color.
  * @returns The color theme.


### PR DESCRIPTION
## Summary
Adds an opt-in `wcagAAEnabled` theme flag that automatically adjusts palette colors and text colors to meet WCAG 2 level AA contrast ratios, plus the contrast-calculation utilities backing it.

## Changes
- Add `getContrastRatio`, `meetsWcagAA`, and `ensureWcagAAContrast` utils in `src/utils/color/index.ts`, which flatten semi-transparent colors over their background before measuring contrast, then darken/lighten a foreground (toward black or white) until it passes AA.
- Add `wcagAAEnabled` option to `theme()` in `src/styles/theme.ts`. When enabled, `applyWcagAAContrast` walks the built theme's palette and adjusts each color's `main`/`dark` and `contrastText` (re-checked against the possibly-shifted `main`), plus `text.primary`/`text.secondary`/`text.disabled`, against the page background. `light` is left untouched since it doubles as a background/overlay tint. Off by default to preserve existing palettes.
- Add `Styles/WCAG AA Contrast` Storybook stories demonstrating the flag on both a deliberately low-contrast custom palette and the package's real default palette (enabled vs. disabled, side by side).
- Update `OverviewBigNumbers` default color from the hardcoded `green` import to `'primary.main'`.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
