### PR TITLE
fix: prevent bg color from rendering when logo url has loaded successfully

### DIFF
--- a/src/components/form/NewOneClickForm/react/ui/fields/input/healthInsurance.field.tsx
+++ b/src/components/form/NewOneClickForm/react/ui/fields/input/healthInsurance.field.tsx
@@ -114,6 +114,34 @@ function RequiredLabel({
   );
 }
 
+function PayerAvatar({
+  name,
+  logoUrl,
+}: Readonly<{ name: string; logoUrl?: string | null }>) {
+  const [logoFailed, setLogoFailed] = useState(false);
+  const logoSrc = logoFailed ? undefined : logoUrl || undefined;
+
+  return (
+    <Avatar
+      src={logoSrc}
+      alt={name[0]?.toUpperCase()}
+      sx={{
+        width: 32,
+        height: 32,
+        borderRadius: 1,
+        bgcolor: logoSrc ? 'transparent' : 'primary.main',
+      }}
+      slotProps={{
+        img: {
+          onError: () => setLogoFailed(true),
+        },
+      }}
+    >
+      {name[0]?.toUpperCase()}
+    </Avatar>
+  );
+}
+
 export function HealthInsuranceInputField({ fieldKey }: { fieldKey: string }) {
   const { field, setValue, setTouched } = useFormField<'healthInsurance'>({
     key: fieldKey,
@@ -205,25 +233,7 @@ export function HealthInsuranceInputField({ fieldKey }: { fieldKey: string }) {
         renderOption={(props, option) => (
           <Box component='li' {...props} key={option.verifiedId}>
             <Stack direction='row' spacing={1.5} alignItems='center'>
-              <Avatar
-                src={option.logoUrl ?? undefined}
-                alt={option.name[0]?.toUpperCase()}
-                sx={{
-                  width: 32,
-                  height: 32,
-                  borderRadius: 1,
-                  bgcolor: 'primary.main',
-                }}
-                slotProps={{
-                  img: {
-                    onError: (e: React.SyntheticEvent<HTMLImageElement>) => {
-                      e.currentTarget.style.display = 'none';
-                    },
-                  },
-                }}
-              >
-                {option.name[0]?.toUpperCase()}
-              </Avatar>
+              <PayerAvatar name={option.name} logoUrl={option.logoUrl} />
               <Typography sx={{ textAlign: 'left' }}>{option.name}</Typography>
             </Stack>
           </Box>

--- a/src/components/form/NewOneClickForm/react/ui/fields/input/healthInsurance.field.tsx
+++ b/src/components/form/NewOneClickForm/react/ui/fields/input/healthInsurance.field.tsx
@@ -124,7 +124,7 @@ function PayerAvatar({
   return (
     <Avatar
       src={logoSrc}
-      alt={name[0]?.toUpperCase()}
+      alt={`${name} logo`}
       sx={{
         width: 32,
         height: 32,

--- a/src/stories/components/form/CredentialForm.stories.tsx
+++ b/src/stories/components/form/CredentialForm.stories.tsx
@@ -448,7 +448,7 @@ const CredentialForm: React.FC = () => {
                   query.set('$skip', params.skip.toString());
 
                 const response = await fetch(
-                  `https://core-api.verified.inc/v2/1-click/health/payers?${query}`,
+                  `http://localhost:3010/1-click/health/payers?${query}`,
                 );
 
                 if (!response.ok) {

--- a/src/stories/components/form/CredentialForm.stories.tsx
+++ b/src/stories/components/form/CredentialForm.stories.tsx
@@ -448,7 +448,7 @@ const CredentialForm: React.FC = () => {
                   query.set('$skip', params.skip.toString());
 
                 const response = await fetch(
-                  `http://localhost:3010/1-click/health/payers?${query}`,
+                  `https://core-api.verified.inc/v2/1-click/health/payers?${query}`,
                 );
 
                 if (!response.ok) {


### PR DESCRIPTION
## Summary
Fixes the health insurance payer avatar showing the theme's primary background color behind successfully loaded logos. The background color now only renders as a fallback when the logo is missing or fails to load.

## Changes
- Extracted a `PayerAvatar` component in `healthInsurance.field.tsx` that tracks logo load failures via state (`onError`), instead of hiding the broken `<img>` with inline styles.
- Avatar background is now `transparent` when a logo URL is available, falling back to `primary.main` with the payer's initial letter only when the logo is missing or fails to load.
- Updated the `CredentialForm` Storybook story to fetch payers from the production endpoint (`https://core-api.verified.inc/v2/1-click/health/payers`) instead of `localhost:3010`.

## Testing
Tested via Storybook using the `CredentialForm` story: open the health insurance field's payer autocomplete and verify that options with a valid logo render the logo without a background color, while options with a missing or failing logo URL render the initial-letter fallback on the primary color background. Reviewers can reproduce the same way by running Storybook and searching for payers in the dropdown.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
