### PR TITLE
chore: add dependabot version updates (weekly, grouped)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Dependabot version updates (security updates are managed org-wide by the
+# "Verified - Public Repos" security configuration). ref: Linear ENG-17
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+# Auto-approve and auto-merge Dependabot PRs for minor/patch updates only.
+# Majors are excluded — they arrive as individual PRs for human review.
+# Safe because the main ruleset requires green status checks before merge:
+# --auto waits for CI. ref: Linear ENG-17
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - id: metadata
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fleet rollout 12/12 (the simplest one): weekly grouped minor/patch npm updates + actions updates. No Dockerfile → no docker ecosystem and no scan gate applicable; public repo → no private-registry block needed.

Part of Linear ENG-17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)